### PR TITLE
support abstract class which implements IProvider or interface extend…

### DIFF
--- a/arouter-api/src/main/java/com/alibaba/android/arouter/base/RouteGroupMap.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/base/RouteGroupMap.java
@@ -1,0 +1,35 @@
+package com.alibaba.android.arouter.base;
+
+import com.alibaba.android.arouter.facade.template.IRouteGroup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Created by metide on 2017/7/7.
+ */
+
+public class RouteGroupMap extends HashMap<String,List<Class<? extends IRouteGroup>>> {
+
+
+    public void put(String k, Class<? extends IRouteGroup> clz){
+        if(k != null && clz != null){
+
+            List<Class<? extends IRouteGroup>> temp;
+
+            if(containsKey(k)){
+                temp = get(k);
+
+                if(!temp.contains(clz)){
+                    temp.add(clz);
+                }
+            }else{
+                temp = new ArrayList<>();
+                temp.add(clz);
+            }
+
+            put(k, temp);
+        }
+    }
+}

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/core/LogisticsCenter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/core/LogisticsCenter.java
@@ -114,7 +114,7 @@ public class LogisticsCenter {
 
         RouteMeta routeMeta = Warehouse.routes.get(postcard.getPath());
         if (null == routeMeta) {    // Maybe its does't exist, or didn't load.
-            Class<? extends IRouteGroup> groupMeta = Warehouse.groupsIndex.get(postcard.getGroup());  // Load route meta.
+            List<Class<? extends IRouteGroup>> groupMeta = Warehouse.groupsIndex.get(postcard.getGroup());  // Load route meta.
             if (null == groupMeta) {
                 throw new NoRouteFoundException(TAG + "There is no route match the path [" + postcard.getPath() + "], in group [" + postcard.getGroup() + "]");
             } else {
@@ -124,8 +124,10 @@ public class LogisticsCenter {
                         logger.debug(TAG, String.format(Locale.getDefault(), "The group [%s] starts loading, trigger by [%s]", postcard.getGroup(), postcard.getPath()));
                     }
 
-                    IRouteGroup iGroupInstance = groupMeta.getConstructor().newInstance();
-                    iGroupInstance.loadInto(Warehouse.routes);
+                    for(Class<? extends IRouteGroup> group : groupMeta){
+                        IRouteGroup iGroupInstance = group.getConstructor().newInstance();
+                        iGroupInstance.loadInto(Warehouse.routes);
+                    }
                     Warehouse.groupsIndex.remove(postcard.getGroup());
 
                     if (ARouter.debuggable()) {

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
@@ -1,10 +1,10 @@
 package com.alibaba.android.arouter.core;
 
+import com.alibaba.android.arouter.base.RouteGroupMap;
 import com.alibaba.android.arouter.base.UniqueKeyTreeMap;
 import com.alibaba.android.arouter.facade.model.RouteMeta;
 import com.alibaba.android.arouter.facade.template.IInterceptor;
 import com.alibaba.android.arouter.facade.template.IProvider;
-import com.alibaba.android.arouter.facade.template.IRouteGroup;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 class Warehouse {
     // Cache route and metas
-    static Map<String, Class<? extends IRouteGroup>> groupsIndex = new HashMap<>();
+    static RouteGroupMap groupsIndex = new RouteGroupMap();
     static Map<String, RouteMeta> routes = new HashMap<>();
 
     // Cache provider

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/IRouteRoot.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/IRouteRoot.java
@@ -1,6 +1,6 @@
 package com.alibaba.android.arouter.facade.template;
 
-import java.util.Map;
+import com.alibaba.android.arouter.base.RouteGroupMap;
 
 /**
  * Root element.
@@ -15,5 +15,5 @@ public interface IRouteRoot {
      * Load routes to input
      * @param routes input
      */
-    void loadInto(Map<String, Class<? extends IRouteGroup>> routes);
+    void loadInto(RouteGroupMap routes);
 }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
@@ -267,7 +267,19 @@ public class RouteProcessor extends AbstractProcessor {
                 for (RouteMeta routeMeta : groupData) {
                     switch (routeMeta.getType()) {
                         case PROVIDER:  // Need cache provider's super class
-                            List<? extends TypeMirror> interfaces = ((TypeElement) routeMeta.getRawType()).getInterfaces();
+
+                            TypeElement typeElement = (TypeElement) routeMeta.getRawType();
+                            List<? extends TypeMirror> interfaces = typeElement.getInterfaces();
+
+                            while (interfaces.size() == 0){
+                                TypeMirror tm = typeElement.getSuperclass();
+                                typeElement = elements.getTypeElement(tm.toString());
+
+                                if(types.isSubtype(tm, iProvider)){
+                                    interfaces = typeElement.getInterfaces();
+                                }
+                            }
+
                             for (TypeMirror tm : interfaces) {
                                 if (types.isSameType(tm, iProvider)) {   // Its implements iProvider interface himself.
                                     // This interface extend the IProvider, so it can be used for mark provider

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
@@ -13,6 +13,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 
@@ -47,6 +48,7 @@ import javax.lang.model.util.Types;
 import static com.alibaba.android.arouter.compiler.utils.Consts.ACTIVITY;
 import static com.alibaba.android.arouter.compiler.utils.Consts.ANNOTATION_TYPE_AUTOWIRED;
 import static com.alibaba.android.arouter.compiler.utils.Consts.ANNOTATION_TYPE_ROUTE;
+import static com.alibaba.android.arouter.compiler.utils.Consts.AROUTER_MAP;
 import static com.alibaba.android.arouter.compiler.utils.Consts.FRAGMENT;
 import static com.alibaba.android.arouter.compiler.utils.Consts.IPROVIDER_GROUP;
 import static com.alibaba.android.arouter.compiler.utils.Consts.IROUTE_GROUP;
@@ -178,14 +180,16 @@ public class RouteProcessor extends AbstractProcessor {
 
                ```Map<String, Class<? extends IRouteGroup>>```
              */
-            ParameterizedTypeName inputMapTypeOfRoot = ParameterizedTypeName.get(
-                    ClassName.get(Map.class),
-                    ClassName.get(String.class),
-                    ParameterizedTypeName.get(
-                            ClassName.get(Class.class),
-                            WildcardTypeName.subtypeOf(ClassName.get(type_IRouteGroup))
-                    )
-            );
+//            ParameterizedTypeName inputMapTypeOfRoot = ParameterizedTypeName.get(
+//                    ClassName.get(Map.class),
+//                    ClassName.get(String.class),
+//                    ParameterizedTypeName.get(
+//                            ClassName.get(Class.class),
+//                            WildcardTypeName.subtypeOf(ClassName.get(type_IRouteGroup))
+//                    )
+//            );
+            TypeMirror rootParam = elements.getTypeElement(AROUTER_MAP).asType();
+            TypeName inputMapTypeOfRoot = ParameterizedTypeName.get(rootParam);
 
             /*
 
@@ -330,7 +334,7 @@ public class RouteProcessor extends AbstractProcessor {
                 }
 
                 // Generate groups
-                String groupFileName = NAME_OF_GROUP + groupName;
+                String groupFileName = NAME_OF_GROUP + groupName + SEPARATOR + moduleName;
                 JavaFile.builder(PACKAGE_OF_GENERATE_FILE,
                         TypeSpec.classBuilder(groupFileName)
                                 .addJavadoc(WARNING_TIPS)

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
@@ -63,4 +63,6 @@ public class Consts {
     public static final String ANNOTATION_TYPE_INTECEPTOR = FACADE_PACKAGE + ".annotation.Interceptor";
     public static final String ANNOTATION_TYPE_ROUTE = FACADE_PACKAGE + ".annotation.Route";
     public static final String ANNOTATION_TYPE_AUTOWIRED = FACADE_PACKAGE + ".annotation.Autowired";
+
+    public static final String AROUTER_MAP = "com.alibaba.android.arouter.base.RouteGroupMap";
 }


### PR DESCRIPTION
支持当扩展自一个继承了IProvider接口或者继承自IProvider接口的抽象类时，无法自动注册对应的Service
直接看代码吧
定义一个抽象类AbstractHelloService
```
public abstract class AbstractHelloService implements HelloService {
    protected Context mContext;
    @Override
    public void init(Context context) {
        mContext = context;
    }
}
```
HelloServiceImpl直接扩展AbstractHelloService
```
@Route(path = "/service/hello")
public class HelloServiceImpl extends AbstractHelloService {

    @Override
    public void sayHello(String name) {
        Toast.makeText(mContext, "Hello " + name, Toast.LENGTH_SHORT).show();
    }
}
```
看一下生成的ARouter$$Providers$$app类内容，没有了HelloService
```
public class ARouter$$Providers$$app implements IProviderGroup {
  @Override
  public void loadInto(Map<String, RouteMeta> providers) {
    providers.put("com.alibaba.android.arouter.facade.service.SerializationService", RouteMeta.build(RouteType.PROVIDER, JsonServiceImpl.class, "/service/json", "service", null, -1, -2147483648));
    providers.put("com.alibaba.android.arouter.demo.testservice.SingleService", RouteMeta.build(RouteType.PROVIDER, SingleService.class, "/service/single", "service", null, -1, -2147483648));
  }
}
```
