### PR TITLE
同时集成androidannotation时，在activity或者fragment使用了androidannotation的注解，会生成…

### DIFF
--- a/arouter-compiler/build.gradle
+++ b/arouter-compiler/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     compile 'com.google.auto.service:auto-service:1.0-rc2'
     compile 'com.squareup:javapoet:1.7.0'
-
+    compile 'org.androidannotations:androidannotations-api:4.3.1'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.apache.commons:commons-collections4:4.1'
 }


### PR DESCRIPTION
…相应带下划线的类，这时arouter就会找到两个路由相同的类，并且无法找到apt生成带下划线的类，通过过滤EActivity和EFragment注解来过滤原生的类，以此来使Arouter使用带下划线的类