### PR TITLE
fix: postcard transition support 0

### DIFF
--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
@@ -43,8 +43,8 @@ public final class Postcard extends RouteMeta {
 
     // Animation
     private Bundle optionsCompat;    // The transition animation of activity
-    private int enterAnim;
-    private int exitAnim;
+    private int enterAnim = -1;
+    private int exitAnim = -1;
 
     public Bundle getOptionsBundle() {
         return optionsCompat;

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
@@ -359,7 +359,7 @@ final class _ARouter {
                             ActivityCompat.startActivity(currentContext, intent, postcard.getOptionsBundle());
                         }
 
-                        if ((0 != postcard.getEnterAnim() || 0 != postcard.getExitAnim()) && currentContext instanceof Activity) {    // Old version.
+                        if ((-1 != postcard.getEnterAnim() && -1 != postcard.getExitAnim()) && currentContext instanceof Activity) {    // Old version.
                             ((Activity) currentContext).overridePendingTransition(postcard.getEnterAnim(), postcard.getExitAnim());
                         }
 


### PR DESCRIPTION
`Postcard` 的 `withTransition` 支持设置值为 0，用来关闭默认动画