### PR TITLE
compat for java8

### DIFF
--- a/arouter-register/src/main/groovy/com/alibaba/android/arouter/register/core/RegisterTransform.groovy
+++ b/arouter-register/src/main/groovy/com/alibaba/android/arouter/register/core/RegisterTransform.groovy
@@ -65,6 +65,7 @@ class RegisterTransform extends Transform {
         Logger.i('Start scan register info in jar file.')
 
         long startTime = System.currentTimeMillis()
+        boolean leftSlash = File.separator == '/'
 
         inputs.each { TransformInput input ->
 
@@ -96,6 +97,9 @@ class RegisterTransform extends Transform {
                     root += File.separator
                 directoryInput.file.eachFileRecurse { File file ->
                     def path = file.absolutePath.replace(root, '')
+                    if (!leftSlash) {
+                        path = path.replaceAll("\\\\", "/")
+                    }
                     if(file.isFile() && ScanUtil.shouldProcessClass(path)){
                         ScanUtil.scanClass(file)
                     }

--- a/arouter-register/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
+++ b/arouter-register/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
@@ -44,7 +44,7 @@ class ScanUtil {
     }
 
     static boolean shouldProcessPreDexJar(String path) {
-        return path.endsWith("classes.jar") && !path.contains("com.android.support") && !path.contains("/android/m2repository")
+        return !path.contains("com.android.support") && !path.contains("/android/m2repository")
     }
 
     static boolean shouldProcessClass(String entryName) {


### PR DESCRIPTION
current version of arouter-register plugin is not worked with java8 like this:
```
android {
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
}
```
This PR fixed the problem