### PR TITLE
拆分结果回调，添加单一结果回调支持，使用Lambda表达式时更加清爽

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,18 +229,47 @@ public class TestInterceptor implements IInterceptor {
 
 4. 处理跳转结果
 ``` java
-// 使用两个参数的navigation方法，可以获取单次跳转的结果
+// 使用带Callback参数的navigation方法，可以获取单次跳转的结果
 ARouter.getInstance().build("/test/1").navigation(this, new NavigationCallback() {
     @Override
     public void onFound(Postcard postcard) {
-      ...
+        Log.d("ARouter", "找到了");
     }
 
     @Override
     public void onLost(Postcard postcard) {
-	...
+        Log.d("ARouter", "找不到了");
+    }
+    
+    @Override
+    public void onArrival(Postcard postcard) {
+        Log.d("ARouter", "跳转完了");
+    }
+
+    @Override
+    public void onFound(Postcard postcard) {
+        Log.d("ARouter", "被拦截了");
     }
 });
+// 或
+ARouter.getInstance().build("/test/1").navigation(this, 
+        new FoundCallback() {...},
+        new LostCallback() {...},
+        new ArrivalCallback() {...}
+        new InterruptCallback() {...});
+// 也可获取单一的跳转结果
+ARouter.getInstance().build("/test/1").navigation(this, new FoundCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new LostCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new ArrivalCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new InterruptCallback() {...});
+```
+如果使用Java 8，Lambda表达式更清爽
+``` java
+ARouter.getInstance().build("/test/1").navigation(this,
+        postcard -> Log.d("ARouter", "找到了"),
+        postcard -> Log.d("ARouter", "找不到了"),
+        postcard -> Log.d("ARouter", "跳转完了"),
+        postcard -> Log.d("ARouter", "被拦截了"));
 ```
 
 5. 自定义全局降级策略

--- a/README_CN.md
+++ b/README_CN.md
@@ -229,18 +229,47 @@ public class TestInterceptor implements IInterceptor {
 
 4. 处理跳转结果
 ``` java
-// 使用两个参数的navigation方法，可以获取单次跳转的结果
+// 使用带Callback参数的navigation方法，可以获取单次跳转的结果
 ARouter.getInstance().build("/test/1").navigation(this, new NavigationCallback() {
     @Override
     public void onFound(Postcard postcard) {
-      ...
+        Log.d("ARouter", "找到了");
     }
 
     @Override
     public void onLost(Postcard postcard) {
-	...
+        Log.d("ARouter", "找不到了");
+    }
+    
+    @Override
+    public void onArrival(Postcard postcard) {
+        Log.d("ARouter", "跳转完了");
+    }
+
+    @Override
+    public void onFound(Postcard postcard) {
+        Log.d("ARouter", "被拦截了");
     }
 });
+// 或
+ARouter.getInstance().build("/test/1").navigation(this, 
+        new FoundCallback() {...},
+        new LostCallback() {...},
+        new ArrivalCallback() {...}
+        new InterruptCallback() {...});
+// 也可获取单一的跳转结果
+ARouter.getInstance().build("/test/1").navigation(this, new FoundCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new LostCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new ArrivalCallback() {...});
+ARouter.getInstance().build("/test/1").navigation(this, new InterruptCallback() {...});
+```
+如果使用Java 8，Lambda表达式更清爽
+``` java
+ARouter.getInstance().build("/test/1").navigation(this,
+        postcard -> Log.d("ARouter", "找到了"),
+        postcard -> Log.d("ARouter", "找不到了"),
+        postcard -> Log.d("ARouter", "跳转完了"),
+        postcard -> Log.d("ARouter", "被拦截了"));
 ```
 
 5. 自定义全局降级策略

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,11 +15,15 @@ android {
                 arguments = [ moduleName : project.getName() ]
             }
         }
+
+        jackOptions {
+            enabled true
+        }
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     signingConfigs {

--- a/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
@@ -16,8 +16,7 @@ import com.alibaba.android.arouter.demo.testinject.TestObj;
 import com.alibaba.android.arouter.demo.testinject.TestParcelable;
 import com.alibaba.android.arouter.demo.testservice.HelloService;
 import com.alibaba.android.arouter.demo.testservice.SingleService;
-import com.alibaba.android.arouter.facade.Postcard;
-import com.alibaba.android.arouter.facade.callback.NavCallback;
+import com.alibaba.android.arouter.facade.callback.InterruptCallback;
 import com.alibaba.android.arouter.launcher.ARouter;
 
 import java.util.ArrayList;
@@ -110,17 +109,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             case R.id.interceptor:
                 ARouter.getInstance()
                         .build("/test/activity4")
-                        .navigation(this, new NavCallback() {
-                            @Override
-                            public void onArrival(Postcard postcard) {
-
-                            }
-
-                            @Override
-                            public void onInterrupt(Postcard postcard) {
-                                Log.d("ARouter", "被拦截了");
-                            }
-                        });
+                        .navigation(this, (InterruptCallback) postcard -> Log.d("ARouter", "被拦截了"));
                 break;
             case R.id.navByUrl:
                 ARouter.getInstance()
@@ -166,27 +155,11 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 ARouter.getInstance().destroy();
                 break;
             case R.id.failNav:
-                ARouter.getInstance().build("/xxx/xxx").navigation(this, new NavCallback() {
-                    @Override
-                    public void onFound(Postcard postcard) {
-                        Log.d("ARouter", "找到了");
-                    }
-
-                    @Override
-                    public void onLost(Postcard postcard) {
-                        Log.d("ARouter", "找不到了");
-                    }
-
-                    @Override
-                    public void onArrival(Postcard postcard) {
-                        Log.d("ARouter", "跳转完了");
-                    }
-
-                    @Override
-                    public void onInterrupt(Postcard postcard) {
-                        Log.d("ARouter", "被拦截了");
-                    }
-                });
+                ARouter.getInstance().build("/xxx/xxx").navigation(this,
+                        postcard -> Log.d("ARouter", "找到了"),
+                        postcard -> Log.d("ARouter", "找不到了"),
+                        postcard -> Log.d("ARouter", "跳转完了"),
+                        postcard -> Log.d("ARouter", "被拦截了"));
                 break;
             case R.id.callSingle:
                 ARouter.getInstance().navigation(SingleService.class).sayHello("Mike");

--- a/app/src/main/java/com/alibaba/android/arouter/demo/SchemeFilterActivity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/SchemeFilterActivity.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import com.alibaba.android.arouter.facade.Postcard;
+import com.alibaba.android.arouter.facade.callback.ArrivalCallback;
 import com.alibaba.android.arouter.facade.callback.NavCallback;
 import com.alibaba.android.arouter.launcher.ARouter;
 
@@ -16,11 +17,6 @@ public class SchemeFilterActivity extends Activity {
 
 //        直接通过ARouter处理外部Uri
         Uri uri = getIntent().getData();
-        ARouter.getInstance().build(uri).navigation(this, new NavCallback() {
-            @Override
-            public void onArrival(Postcard postcard) {
-                finish();
-            }
-        });
+        ARouter.getInstance().build(uri).navigation(this, (ArrivalCallback) postcard -> finish());
     }
 }

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testinterceptor/Test1Interceptor.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testinterceptor/Test1Interceptor.java
@@ -37,32 +37,14 @@ public class Test1Interceptor implements IInterceptor {
             ab.setCancelable(false);
             ab.setTitle("温馨提醒");
             ab.setMessage("想要跳转到Test4Activity么？(触发了\"/inter/test1\"拦截器，拦截了本次跳转)");
-            ab.setNegativeButton("继续", new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    callback.onContinue(postcard);
-                }
-            });
-            ab.setNeutralButton("算了", new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    callback.onInterrupt(null);
-                }
-            });
-            ab.setPositiveButton("加点料", new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    postcard.withString("extra", "我是在拦截器中附加的参数");
-                    callback.onContinue(postcard);
-                }
+            ab.setNegativeButton("继续", (dialog, which) -> callback.onContinue(postcard));
+            ab.setNeutralButton("算了", (dialog, which) -> callback.onInterrupt(null));
+            ab.setPositiveButton("加点料", (dialog, which) -> {
+                postcard.withString("extra", "我是在拦截器中附加的参数");
+                callback.onContinue(postcard);
             });
 
-            MainLooper.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    ab.create().show();
-                }
-            });
+            MainLooper.runOnUiThread(() -> ab.create().show());
         } else {
             callback.onContinue(postcard);
         }

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
@@ -12,7 +12,12 @@ import android.support.annotation.RequiresApi;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.util.SparseArray;
 
+import com.alibaba.android.arouter.facade.callback.ArrivalCallback;
+import com.alibaba.android.arouter.facade.callback.FoundCallback;
+import com.alibaba.android.arouter.facade.callback.InterruptCallback;
+import com.alibaba.android.arouter.facade.callback.LostCallback;
 import com.alibaba.android.arouter.facade.callback.NavigationCallback;
+import com.alibaba.android.arouter.facade.callback.NavigationCallbackWrapper;
 import com.alibaba.android.arouter.facade.model.RouteMeta;
 import com.alibaba.android.arouter.facade.service.SerializationService;
 import com.alibaba.android.arouter.facade.template.IProvider;
@@ -152,6 +157,51 @@ public final class Postcard extends RouteMeta {
     /**
      * Navigation to the route with path in postcard.
      *
+     * @param context Activity and so on.
+     */
+    public Object navigation(Context context, FoundCallback callback) {
+        return navigation(context, callback, null, null, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param context Activity and so on.
+     */
+    public Object navigation(Context context, LostCallback callback) {
+        return navigation(context, null, callback, null, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param context Activity and so on.
+     */
+    public Object navigation(Context context, ArrivalCallback callback) {
+        return navigation(context, null, null, callback, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param context Activity and so on.
+     */
+    public Object navigation(Context context, InterruptCallback callback) {
+        return navigation(context, null, null, null, callback);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param context Activity and so on.
+     */
+    public Object navigation(Context context, FoundCallback found, LostCallback lost, ArrivalCallback arrival, InterruptCallback interrupt) {
+        return ARouter.getInstance().navigation(context, this, -1, new NavigationCallbackWrapper(found, lost, arrival, interrupt));
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
      * @param mContext    Activity and so on.
      * @param requestCode startActivityForResult's param
      */
@@ -167,6 +217,56 @@ public final class Postcard extends RouteMeta {
      */
     public void navigation(Activity mContext, int requestCode, NavigationCallback callback) {
         ARouter.getInstance().navigation(mContext, this, requestCode, callback);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param mContext    Activity and so on.
+     * @param requestCode startActivityForResult's param
+     */
+    public void navigation(Activity mContext, int requestCode, FoundCallback callback) {
+        navigation(mContext, requestCode, callback, null, null, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param mContext    Activity and so on.
+     * @param requestCode startActivityForResult's param
+     */
+    public void navigation(Activity mContext, int requestCode, LostCallback callback) {
+        navigation(mContext, requestCode, null, callback, null, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param mContext    Activity and so on.
+     * @param requestCode startActivityForResult's param
+     */
+    public void navigation(Activity mContext, int requestCode, ArrivalCallback callback) {
+        navigation(mContext, requestCode, null, null, callback, null);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param mContext    Activity and so on.
+     * @param requestCode startActivityForResult's param
+     */
+    public void navigation(Activity mContext, int requestCode, InterruptCallback callback) {
+        navigation(mContext, requestCode, null, null, null, callback);
+    }
+
+    /**
+     * Navigation to the route with path in postcard.
+     *
+     * @param mContext    Activity and so on.
+     * @param requestCode startActivityForResult's param
+     */
+    public void navigation(Activity mContext, int requestCode, FoundCallback found, LostCallback lost, ArrivalCallback arrival, InterruptCallback interrupt) {
+        ARouter.getInstance().navigation(mContext, this, requestCode, new NavigationCallbackWrapper(found, lost, arrival, interrupt));
     }
 
     /**

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/ArrivalCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/ArrivalCallback.java
@@ -1,0 +1,20 @@
+package com.alibaba.android.arouter.facade.callback;
+
+import com.alibaba.android.arouter.facade.Postcard;
+
+/**
+ * Callback after arrive at the destination.
+ *
+ * @author Victor Chiu <a href="mailto:4332weizi@gmail.com">Contact me.</a>
+ * @version 1.3.2
+ * @since 2018/4/21 14:13
+ */
+public interface ArrivalCallback {
+
+    /**
+     * Callback after navigation.
+     *
+     * @param postcard meta
+     */
+    void onArrival(Postcard postcard);
+}

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/FoundCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/FoundCallback.java
@@ -1,0 +1,20 @@
+package com.alibaba.android.arouter.facade.callback;
+
+import com.alibaba.android.arouter.facade.Postcard;
+
+/**
+ * Callback after found the destination.
+ *
+ * @author Victor Chiu <a href="mailto:4332weizi@gmail.com">Contact me.</a>
+ * @version 1.3.2
+ * @since 2018/4/21 14:13
+ */
+public interface FoundCallback {
+
+    /**
+     * Callback when find the destination.
+     *
+     * @param postcard meta
+     */
+    void onFound(Postcard postcard);
+}

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/InterruptCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/InterruptCallback.java
@@ -1,0 +1,20 @@
+package com.alibaba.android.arouter.facade.callback;
+
+import com.alibaba.android.arouter.facade.Postcard;
+
+/**
+ * Callback on navigation interrupt.
+ *
+ * @author Victor Chiu <a href="mailto:4332weizi@gmail.com">Contact me.</a>
+ * @version 1.3.2
+ * @since 2018/4/21 14:13
+ */
+public interface InterruptCallback {
+
+    /**
+     * Callback on interrupt.
+     *
+     * @param postcard meta
+     */
+    void onInterrupt(Postcard postcard);
+}

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/LostCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/LostCallback.java
@@ -1,0 +1,20 @@
+package com.alibaba.android.arouter.facade.callback;
+
+import com.alibaba.android.arouter.facade.Postcard;
+
+/**
+ * Callback after after lose your way.
+ *
+ * @author Victor Chiu <a href="mailto:4332weizi@gmail.com">Contact me.</a>
+ * @version 1.3.2
+ * @since 2018/4/21 14:13
+ */
+public interface LostCallback {
+
+    /**
+     * Callback after lose your way.
+     *
+     * @param postcard meta
+     */
+    void onLost(Postcard postcard);
+}

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavCallback.java
@@ -9,6 +9,7 @@ import com.alibaba.android.arouter.facade.Postcard;
  * @version 1.0
  * @since 2017/4/10 下午12:59
  */
+@Deprecated
 public abstract class NavCallback implements NavigationCallback {
     @Override
     public void onFound(Postcard postcard) {

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavigationCallback.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavigationCallback.java
@@ -1,41 +1,12 @@
 package com.alibaba.android.arouter.facade.callback;
 
-import com.alibaba.android.arouter.facade.Postcard;
-
 /**
  * Callback after navigation.
  *
  * @author Alex <a href="mailto:zhilong.liu@aliyun.com">Contact me.</a>
- * @version 1.0
+ * @version 1.3.2
  * @since 2016/9/22 14:15
  */
-public interface NavigationCallback {
+public interface NavigationCallback extends FoundCallback, LostCallback, ArrivalCallback, InterruptCallback {
 
-    /**
-     * Callback when find the destination.
-     *
-     * @param postcard meta
-     */
-    void onFound(Postcard postcard);
-
-    /**
-     * Callback after lose your way.
-     *
-     * @param postcard meta
-     */
-    void onLost(Postcard postcard);
-
-    /**
-     * Callback after navigation.
-     *
-     * @param postcard meta
-     */
-    void onArrival(Postcard postcard);
-
-    /**
-     * Callback on interrupt.
-     *
-     * @param postcard meta
-     */
-    void onInterrupt(Postcard postcard);
 }

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavigationCallbackWrapper.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/callback/NavigationCallbackWrapper.java
@@ -1,0 +1,53 @@
+package com.alibaba.android.arouter.facade.callback;
+
+import com.alibaba.android.arouter.facade.Postcard;
+
+/**
+ * Proxying implementation of NavigationCallback.
+ *
+ * @author Victor Chiu <a href="mailto:4332weizi@gmail.com">Contact me.</a>
+ * @version 1.3.2
+ * @since 2018/4/21 14:14
+ */
+public class NavigationCallbackWrapper implements NavigationCallback {
+
+    private FoundCallback mFoundCallback;
+    private LostCallback mLostCallback;
+    private ArrivalCallback mArrivalCallback;
+    private InterruptCallback mInterruptCallback;
+
+    public NavigationCallbackWrapper(FoundCallback found, LostCallback lost, ArrivalCallback arrival, InterruptCallback interrupt) {
+        mFoundCallback = found;
+        mLostCallback = lost;
+        mArrivalCallback = arrival;
+        mInterruptCallback = interrupt;
+    }
+
+    @Override
+    public void onInterrupt(Postcard postcard) {
+        if (mInterruptCallback != null) {
+            mInterruptCallback.onInterrupt(postcard);
+        }
+    }
+
+    @Override
+    public void onLost(Postcard postcard) {
+        if (mLostCallback != null) {
+            mLostCallback.onLost(postcard);
+        }
+    }
+
+    @Override
+    public void onArrival(Postcard postcard) {
+        if (mArrivalCallback != null) {
+            mArrivalCallback.onArrival(postcard);
+        }
+    }
+
+    @Override
+    public void onFound(Postcard postcard) {
+        if (mFoundCallback != null) {
+            mFoundCallback.onFound(postcard);
+        }
+    }
+}


### PR DESCRIPTION
项目中普遍使用Lambda表达式，ARouter的回调方式看起来太突兀。
所以拆分了navigation的结果回调，使用Lambda表达式时更加清爽。
``` java
ARouter.getInstance().build("/test/1").navigation(this, (ArrivalCallback) postcard -> finish());
ARouter.getInstance().build("/test/1").navigation(this,
        postcard -> Log.d("ARouter", "找到了"),
        postcard -> Log.d("ARouter", "找不到了"),
        postcard -> Log.d("ARouter", "跳转完了"),
        postcard -> Log.d("ARouter", "被拦截了"));
```