### PR TITLE
只有当对象参数不为空时才会注入，以免覆盖初始值

### DIFF
--- a/app/src/main/java/com/alibaba/android/arouter/demo/BlankFragment.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/BlankFragment.java
@@ -19,7 +19,7 @@ import com.alibaba.android.arouter.facade.annotation.Route;
 public class BlankFragment extends Fragment {
 
     @Autowired
-    String name;
+    String name = "";
 
     @Autowired(required = true)
     TestObj obj;

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
@@ -40,6 +40,12 @@ public class Test1Activity extends AppCompatActivity {
     float fl = 12.00f;
 
     @Autowired
+    byte byt = 0;
+
+    @Autowired(required = true)
+    Byte bytObj = 0;
+
+    @Autowired
     double dou = 12.01d;
 
     @Autowired

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
@@ -60,13 +60,20 @@ public class Test1Activity extends AppCompatActivity {
     @Autowired
     Map<String, List<TestObj>> map;
 
-    private long high;
-
     @Autowired
     String url;
 
+    private long high;
+
     @Autowired
-    HelloService helloService;
+    private HelloService helloService;
+
+    public void setHelloService(HelloService service) {
+        if (service == null) {
+            throw new NullPointerException("you must implement the 'HelloService'");
+        }
+        helloService = service;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test3Activity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test3Activity.java
@@ -21,7 +21,7 @@ public class Test3Activity extends AppCompatActivity {
     int age;
 
     @Autowired(name = "boy")
-    boolean girl;
+    private boolean girl;
 
     // 这个字段没有注解，是不会自动注入的
     private long high;
@@ -33,7 +33,19 @@ public class Test3Activity extends AppCompatActivity {
 
         String params = String.format("name=%s, age=%s, girl=%s, high=%s", name, age, girl, high);
 
-        ((TextView)findViewById(R.id.test)).setText("I am " + Test3Activity.class.getName());
-        ((TextView)findViewById(R.id.test2)).setText(params);
+        ((TextView) findViewById(R.id.test)).setText("I am " + Test3Activity.class.getName());
+        ((TextView) findViewById(R.id.test2)).setText(params);
+    }
+
+    public void setGirl(boolean boy) {
+        girl = boy;
+    }
+
+    public boolean getGirl() {
+        return girl;
+    }
+
+    public int getAge() {
+        return age;
     }
 }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -253,27 +253,37 @@ public class AutowiredProcessor extends AbstractProcessor {
 
     private String buildStatement(String originalValue, String statement, int type, boolean isActivity) {
         if (type == TypeKind.BOOLEAN.ordinal()) {
-            statement += (isActivity ? ("getBooleanExtra($S, " + originalValue + ")") : ("getBoolean($S)"));
+            statement += (isActivity ? ("getBooleanExtra($S, " + originalValue + ")")
+                    : ("getBoolean($S, " + originalValue + ")"));
         } else if (type == TypeKind.BYTE.ordinal()) {
-            statement += (isActivity ? ("getByteExtra($S, " + originalValue + ")") : ("getByte($S)"));
+            statement += (isActivity ? ("getByteExtra($S, " + originalValue + ")")
+                    : ("getByte($S, " + originalValue + ")"));
         } else if (type == TypeKind.SHORT.ordinal()) {
-            statement += (isActivity ? ("getShortExtra($S, " + originalValue + ")") : ("getShort($S)"));
+            statement += (isActivity ? ("getShortExtra($S, " + originalValue + ")")
+                    : ("getShort($S, " + originalValue + ")"));
         } else if (type == TypeKind.INT.ordinal()) {
-            statement += (isActivity ? ("getIntExtra($S, " + originalValue + ")") : ("getInt($S)"));
+            statement += (isActivity ? ("getIntExtra($S, " + originalValue + ")")
+                    : ("getInt($S, " + originalValue + ")"));
         } else if (type == TypeKind.LONG.ordinal()) {
-            statement += (isActivity ? ("getLongExtra($S, " + originalValue + ")") : ("getLong($S)"));
+            statement += (isActivity ? ("getLongExtra($S, " + originalValue + ")")
+                    : ("getLong($S, " + originalValue + ")"));
         } else if (type == TypeKind.CHAR.ordinal()) {
-            statement += (isActivity ? ("getCharExtra($S, " + originalValue + ")") : ("getChar($S)"));
+            statement += (isActivity ? ("getCharExtra($S, " + originalValue + ")")
+                    : ("getChar($S, " + originalValue + ")"));
         } else if (type == TypeKind.FLOAT.ordinal()) {
-            statement += (isActivity ? ("getFloatExtra($S, " + originalValue + ")") : ("getFloat($S)"));
+            statement += (isActivity ? ("getFloatExtra($S, " + originalValue + ")")
+                    : ("getFloat($S, " + originalValue + ")"));
         } else if (type == TypeKind.DOUBLE.ordinal()) {
-            statement += (isActivity ? ("getDoubleExtra($S, " + originalValue + ")") : ("getDouble($S)"));
+            statement += (isActivity ? ("getDoubleExtra($S, " + originalValue + ")")
+                    : ("getDouble($S, " + originalValue + ")"));
         } else if (type == TypeKind.STRING.ordinal()) {
             statement += (isActivity ? ("getStringExtra($S)") : ("getString($S)"));
         } else if (type == TypeKind.PARCELABLE.ordinal()) {
             statement += (isActivity ? ("getParcelableExtra($S)") : ("getParcelable($S)"));
         } else if (type == TypeKind.OBJECT.ordinal()) {
-            statement = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new $T<$T>(){}.getType())";
+            statement = "serializationService.parseObject(substitute." +
+                    (isActivity ? "getIntent()." : "getArguments().") +
+                    (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new $T<$T>(){}.getType())";
         }
 
         return statement;

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -62,14 +62,15 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 @SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes({ANNOTATION_TYPE_AUTOWIRED})
 public class AutowiredProcessor extends AbstractProcessor {
+    private static final ClassName ARouterClass = ClassName.get("com.alibaba.android.arouter.launcher", "ARouter");
+    private static final ClassName AndroidLog = ClassName.get("android.util", "Log");
+    private static final ClassName TypeWrapperClass = ClassName.get("com.alibaba.android.arouter.facade.model", "TypeWrapper");
     private Filer mFiler;       // File util, write class file into disk.
     private Logger logger;
     private Types types;
     private TypeUtils typeUtils;
     private Elements elements;
     private Map<TypeElement, List<Element>> parentAndChild = new HashMap<>();   // Contain field need autowired and his super class.
-    private static final ClassName ARouterClass = ClassName.get("com.alibaba.android.arouter.launcher", "ARouter");
-    private static final ClassName AndroidLog = ClassName.get("android.util", "Log");
 
     @Override
     public synchronized void init(ProcessingEnvironment processingEnvironment) {
@@ -191,6 +192,7 @@ public class AutowiredProcessor extends AbstractProcessor {
                             injectMethodBuilder.addStatement(
                                     "substitute." + fieldName + " = " + statement,
                                     (StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name()),
+                                    TypeWrapperClass,
                                     ClassName.get(element.asType())
                             );
                             injectMethodBuilder.nextControlFlow("else");
@@ -227,14 +229,14 @@ public class AutowiredProcessor extends AbstractProcessor {
         if (type == TypeKind.BOOLEAN.ordinal()) {
             statement += (isActivity ? ("getBooleanExtra($S, " + originalValue + ")") : ("getBoolean($S)"));
         } else if (type == TypeKind.BYTE.ordinal()) {
-            statement += (isActivity ? ("getByteExtra($S, " + originalValue + "") : ("getByte($S)"));
+            statement += (isActivity ? ("getByteExtra($S, " + originalValue + ")") : ("getByte($S)"));
         } else if (type == TypeKind.SHORT.ordinal()) {
             statement += (isActivity ? ("getShortExtra($S, " + originalValue + ")") : ("getShort($S)"));
         } else if (type == TypeKind.INT.ordinal()) {
             statement += (isActivity ? ("getIntExtra($S, " + originalValue + ")") : ("getInt($S)"));
         } else if (type == TypeKind.LONG.ordinal()) {
             statement += (isActivity ? ("getLongExtra($S, " + originalValue + ")") : ("getLong($S)"));
-        }else if(type == TypeKind.CHAR.ordinal()){
+        } else if (type == TypeKind.CHAR.ordinal()) {
             statement += (isActivity ? ("getCharExtra($S, " + originalValue + ")") : ("getChar($S)"));
         } else if (type == TypeKind.FLOAT.ordinal()) {
             statement += (isActivity ? ("getFloatExtra($S, " + originalValue + ")") : ("getFloat($S)"));
@@ -245,7 +247,7 @@ public class AutowiredProcessor extends AbstractProcessor {
         } else if (type == TypeKind.PARCELABLE.ordinal()) {
             statement += (isActivity ? ("getParcelableExtra($S)") : ("getParcelable($S)"));
         } else if (type == TypeKind.OBJECT.ordinal()) {
-            statement = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new com.alibaba.android.arouter.facade.model.TypeWrapper<$T>(){}.getType())";
+            statement = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new $T<$T>(){}.getType())";
         }
 
         return statement;

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -1,6 +1,6 @@
 package com.alibaba.android.arouter.compiler.processor;
 
-import com.alibaba.android.arouter.compiler.utils.ARouterAccessExecption;
+import com.alibaba.android.arouter.compiler.utils.ARouterAccessException;
 import com.alibaba.android.arouter.compiler.utils.Consts;
 import com.alibaba.android.arouter.compiler.utils.Logger;
 import com.alibaba.android.arouter.compiler.utils.TypeUtils;
@@ -330,7 +330,7 @@ public class AutowiredProcessor extends AbstractProcessor {
     /**
      * 把value赋值给element代表的成员变量，优先调用setter方法
      */
-    private String setValue(String scope, Element element, String value) throws ARouterAccessExecption {
+    private String setValue(String scope, Element element, String value) throws ARouterAccessException {
         final String variableName = element.getSimpleName().toString();
         final String methodName = "set" + toVarStr(variableName);
         final ExecutableElement method = publicSetterMethods.get(methodName);
@@ -338,13 +338,13 @@ public class AutowiredProcessor extends AbstractProcessor {
             return scope + "." + methodName + "(" + value + ")";
         } else {
             if (element.getModifiers().contains(Modifier.PRIVATE)) {
-                throw new ARouterAccessExecption(element, "private or internal", methodName);
+                throw new ARouterAccessException(element, "private or internal", methodName);
             }
             return scope + "." + variableName + " = " + value;
         }
     }
 
-    private String getValue(String scope, Element element) throws ARouterAccessExecption {
+    private String getValue(String scope, Element element) throws ARouterAccessException {
         final String variableName = element.getSimpleName().toString();
         final String methodName = "get" + toVarStr(variableName);
         final ExecutableElement method = publicGetterMethods.get(methodName);
@@ -352,7 +352,7 @@ public class AutowiredProcessor extends AbstractProcessor {
             return scope + '.' + methodName + "()";
         } else {
             if (element.getModifiers().contains(Modifier.PRIVATE)) {
-                throw new ARouterAccessExecption(element, "private or internal", methodName);
+                throw new ARouterAccessException(element, "private or internal", methodName);
             }
             return scope + "." + variableName;
         }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessException.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessException.java
@@ -9,9 +9,9 @@ import javax.lang.model.element.TypeElement;
  * YY: 909017428
  */
 
-public class ARouterAccessExecption extends IllegalAccessException {
+public class ARouterAccessException extends IllegalAccessException {
 
-    public ARouterAccessExecption(Element field, String modifier, String method) {
+    public ARouterAccessException(Element field, String modifier, String method) {
         super("The autowired fields CAN NOT BE '" + modifier + "' unless you provide a public " + method + " method!!! please check field ["
                 + field.getSimpleName() + "] in class [" + ((TypeElement) field.getEnclosingElement()).getQualifiedName() + "]");
     }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessException.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessException.java
@@ -3,12 +3,6 @@ package com.alibaba.android.arouter.compiler.utils;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
-/**
- * Created by 张宇 on 2018/5/2.
- * E-mail: zhangyu4@yy.com
- * YY: 909017428
- */
-
 public class ARouterAccessException extends IllegalAccessException {
 
     public ARouterAccessException(Element field, String modifier, String method) {

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessExecption.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/ARouterAccessExecption.java
@@ -1,0 +1,18 @@
+package com.alibaba.android.arouter.compiler.utils;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Created by 张宇 on 2018/5/2.
+ * E-mail: zhangyu4@yy.com
+ * YY: 909017428
+ */
+
+public class ARouterAccessExecption extends IllegalAccessException {
+
+    public ARouterAccessExecption(Element field, String modifier, String method) {
+        super("The autowired fields CAN NOT BE '" + modifier + "' unless you provide a public " + method + " method!!! please check field ["
+                + field.getSimpleName() + "] in class [" + ((TypeElement) field.getEnclosingElement()).getQualifiedName() + "]");
+    }
+}

--- a/module-java/build.gradle
+++ b/module-java/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
     compile project(':arouter-api')
     compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
-    annotationProcessor 'com.alibaba:arouter-compiler:1.0.3'
+    annotationProcessor project(':arouter-compiler')
 }
 android {
     compileSdkVersion Integer.parseInt(COMPILE_SDK_VERSION)
@@ -15,7 +15,7 @@ android {
 
         javaCompileOptions {
             annotationProcessorOptions {
-                arguments = [ moduleName : project.getName() ]
+                arguments = [moduleName: project.getName()]
             }
         }
     }

--- a/module-kotlin/build.gradle
+++ b/module-kotlin/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    kapt 'com.alibaba:arouter-compiler:1.0.3'
+    kapt project(':arouter-compiler')
 }
 android {
     compileSdkVersion Integer.parseInt(COMPILE_SDK_VERSION)

--- a/module-kotlin/build.gradle
+++ b/module-kotlin/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 
 kapt {

--- a/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
+++ b/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
@@ -11,10 +11,10 @@ import kotlinx.android.synthetic.main.activity_kotlin_test.*
 class KotlinTestActivity : Activity() {
 
     @Autowired
-    var name: String? = null
+    lateinit var name: String
 
     @Autowired
-    var age: Int? = 0
+    var age: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         ARouter.getInstance().inject(this)  // Start auto inject.

--- a/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
+++ b/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
@@ -11,9 +11,10 @@ import kotlinx.android.synthetic.main.activity_kotlin_test.*
 class KotlinTestActivity : Activity() {
 
     @Autowired
-    @JvmField var name: String? = null
+    var name: String? = null
+
     @Autowired
-    @JvmField var age: Int? = 0
+    var age: Int? = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         ARouter.getInstance().inject(this)  // Start auto inject.

--- a/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
+++ b/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
@@ -16,6 +16,12 @@ class KotlinTestActivity : Activity() {
     @Autowired
     var age: Int = 0
 
+    @Autowired
+    var isSth = false
+
+    @Autowired(name = "systemIs")
+    var `is` = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         ARouter.getInstance().inject(this)  // Start auto inject.
 


### PR DESCRIPTION
1.修复注入byte类型的代码生成括号错误：
statement += (isActivity ? ("getByteExtra($S, " + originalValue + "") : ("getByte($S)"));
statement += (isActivity ? ("getByteExtra($S, " + originalValue + ")") : ("getByte($S)"));

2.TypeWrapper生成代码改为import形式：
private static final ClassName TypeWrapperClass = ClassName.get("com.alibaba.android.arouter.facade.model", "TypeWrapper");

3.注入对象时，只有注入的参数不为空时才会赋值。以免没有参数时空值覆盖初始值
待注入代码：
@Autowired
String name = "jack";

生成代码：
final String tempValue_0 = substitute.name = substitute.getIntent().getStringExtra("name");
if(null != tempValue_0) {
  substitute.name = tempValue_0;
}