### PR TITLE
添加混淆规则，防止注入失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ ARouter.getInstance().build("/test/1")
 
 # 如果使用了 单类注入，即不定义接口实现 IProvider，需添加下面规则，保护实现
 -keep class * implements com.alibaba.android.arouter.facade.template.IProvider
+
+# 如果在非Activity类中使用了@Autowired 来进行注入，需添加下面规则，防止找不到对应的 被注解类名$$ARouter$$Autowired 来进行注入
+-keepnames class * {
+    @com.alibaba.android.arouter.facade.annotation.Autowired <fields>;
+}
 ```
 
 6. 使用 Gradle 插件实现路由表的自动加载

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ARouter.getInstance().build("/test/1")
 # 如果使用了 单类注入，即不定义接口实现 IProvider，需添加下面规则，保护实现
 -keep class * implements com.alibaba.android.arouter.facade.template.IProvider
 
-# 如果在非Activity类中使用了@Autowired 来进行注入，需添加下面规则，防止找不到对应的 被注解类名$$ARouter$$Autowired 来进行注入
+# 如果在非Activity类中使用了@Autowired 来进行注入，需添加下面规则，防止注入失败
 -keepnames class * {
     @com.alibaba.android.arouter.facade.annotation.Autowired <fields>;
 }


### PR DESCRIPTION
在非Activity类中使用@Autowired存在这样一个问题：被注解类会被混淆掉，而类名$$ARouter$$Autowired保持不变，导致无法找到对应的ISyringe实例来进行变量注入。