### PR TITLE
添加针对包装器类型变量处成员赋值“,针对require类型为true数据，若未传递相应字段则直抛出异常

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     signingConfigs {

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
@@ -33,8 +33,11 @@ public class Test1Activity extends AppCompatActivity {
     @Autowired(name = "boy")
     boolean girl;
 
-    @Autowired(name = "boyyuu",required = true)
-    char ch = 'A';
+    @Autowired(name = "teger", required = true)
+    Integer girlInteger = null;
+
+    @Autowired(name = "boyyuu", required = true)
+    Character ch = 'A';
 
     @Autowired
     float fl = 12.00f;

--- a/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/testactivity/Test1Activity.java
@@ -33,7 +33,7 @@ public class Test1Activity extends AppCompatActivity {
     @Autowired(name = "boy")
     boolean girl;
 
-    @Autowired
+    @Autowired(name = "boyyuu",required = true)
     char ch = 'A';
 
     @Autowired

--- a/arouter-api/build.gradle
+++ b/arouter-api/build.gradle
@@ -24,8 +24,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/ISyringe.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/ISyringe.java
@@ -1,5 +1,7 @@
 package com.alibaba.android.arouter.facade.template;
 
+import java.io.Serializable;
+
 /**
  * Template of syringe
  *
@@ -9,4 +11,8 @@ package com.alibaba.android.arouter.facade.template;
  */
 public interface ISyringe {
     void inject(Object target);
+
+    default <T extends Serializable> T primitiveParse(Serializable value){
+        return (T) value;
+    }
 }

--- a/arouter-compiler/build.gradle
+++ b/arouter-compiler/build.gradle
@@ -9,8 +9,8 @@ ext {
 }
 
 compileJava {
-    sourceCompatibility = '1.7'
-    targetCompatibility = '1.7'
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
 }
 
 dependencies {

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -212,7 +212,7 @@ public class AutowiredProcessor extends AbstractProcessor {
                         // Validator
                         if (fieldConfig.required()) {  // Primitive wont be check.
                             injectMethodBuilder.beginControlFlow(String.format(Locale.CHINA, "if (null == %s)", judgeStr));
-                            injectMethodBuilder.addStatement(String.format(Locale.CHINA, "throw new RuntimeException( \"%s::::-> the field '%s' is not inject,in class '%s'!\")", Consts.TAG, fieldName, ClassName.get(parent).getClass().getName()));
+                            injectMethodBuilder.addStatement(String.format(Locale.CHINA, "throw new RuntimeException( \"%s::::-> the field '%s' is not inject,in class '%s'!\")", Consts.TAG, fieldName, ClassName.get(parent)));
                             injectMethodBuilder.endControlFlow();
                         }
                     }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -141,6 +142,7 @@ public class AutowiredProcessor extends AbstractProcessor {
 
                 injectMethodBuilder.addStatement("serializationService = $T.getInstance().navigation($T.class)", ARouterClass, ClassName.get(type_JsonService));
                 injectMethodBuilder.addStatement("$T substitute = ($T)target", ClassName.get(parent), ClassName.get(parent));
+                injectMethodBuilder.addStatement("java.io.Serializable temp = null");
 
                 // Generate method body, start inject.
                 for (Element element : childs) {
@@ -174,7 +176,7 @@ public class AutowiredProcessor extends AbstractProcessor {
                         }
                     } else {    // It's normal intent value
                         String originalValue = "substitute." + fieldName;
-                        String statement = "substitute." + fieldName + " = substitute.";
+                        String statement = "substitute.";
                         boolean isActivity = false;
                         if (types.isSubtype(parent.asType(), activityTm)) {  // Activity, then use getIntent()
                             isActivity = true;
@@ -185,11 +187,13 @@ public class AutowiredProcessor extends AbstractProcessor {
                             throw new IllegalAccessException("The field [" + fieldName + "] need autowired from intent, its parent must be activity or fragment!");
                         }
 
-                        statement = buildStatement(originalValue, statement, typeUtils.typeExchange(element), isActivity);
-                        if (statement.startsWith("serializationService.")) {   // Not mortals
+                        String judgeStr;
+                        if (typeUtils.typeExchange(element) == TypeKind.OBJECT.ordinal()) {
+                            judgeStr = originalValue;
+                            String right = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new com.alibaba.android.arouter.facade.model.TypeWrapper<$T>(){}.getType())";
                             injectMethodBuilder.beginControlFlow("if (null != serializationService)");
                             injectMethodBuilder.addStatement(
-                                    "substitute." + fieldName + " = " + statement,
+                                    "substitute." + fieldName + " = " + right,
                                     (StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name()),
                                     ClassName.get(element.asType())
                             );
@@ -198,14 +202,17 @@ public class AutowiredProcessor extends AbstractProcessor {
                                     "$T.e(\"" + Consts.TAG + "\", \"You want automatic inject the field '" + fieldName + "' in class '$T' , then you should implement 'SerializationService' to support object auto inject!\")", AndroidLog, ClassName.get(parent));
                             injectMethodBuilder.endControlFlow();
                         } else {
-                            injectMethodBuilder.addStatement(statement, StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name());
+                            judgeStr = "temp";
+                            injectMethodBuilder.addStatement(buildStatement(statement, typeUtils.typeExchange(element), isActivity), StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name());
+                            injectMethodBuilder.beginControlFlow("if (null != temp) ");
+                            injectMethodBuilder.addStatement(String.format(Locale.CHINA, "%s = primitiveParse(%s)", originalValue, "temp"));
+                            injectMethodBuilder.endControlFlow();
                         }
 
                         // Validator
-                        if (fieldConfig.required() && !element.asType().getKind().isPrimitive()) {  // Primitive wont be check.
-                            injectMethodBuilder.beginControlFlow("if (null == substitute." + fieldName + ")");
-                            injectMethodBuilder.addStatement(
-                                    "$T.e(\"" + Consts.TAG + "\", \"The field '" + fieldName + "' is null, in class '\" + $T.class.getName() + \"!\")", AndroidLog, ClassName.get(parent));
+                        if (fieldConfig.required()) {  // Primitive wont be check.
+                            injectMethodBuilder.beginControlFlow(String.format(Locale.CHINA, "if (null == %s)", judgeStr));
+                            injectMethodBuilder.addStatement(String.format(Locale.CHINA, "throw new RuntimeException( \"%s::::-> the field '%s' is not inject,in class '%s'!\")", Consts.TAG, fieldName, ClassName.get(parent).getClass().getName()));
                             injectMethodBuilder.endControlFlow();
                         }
                     }
@@ -223,32 +230,22 @@ public class AutowiredProcessor extends AbstractProcessor {
         }
     }
 
-    private String buildStatement(String originalValue, String statement, int type, boolean isActivity) {
-        if (type == TypeKind.BOOLEAN.ordinal()) {
-            statement += (isActivity ? ("getBooleanExtra($S, " + originalValue + ")") : ("getBoolean($S)"));
-        } else if (type == TypeKind.BYTE.ordinal()) {
-            statement += (isActivity ? ("getByteExtra($S, " + originalValue + ")") : ("getByte($S)"));
-        } else if (type == TypeKind.SHORT.ordinal()) {
-            statement += (isActivity ? ("getShortExtra($S, " + originalValue + ")") : ("getShort($S)"));
-        } else if (type == TypeKind.INT.ordinal()) {
-            statement += (isActivity ? ("getIntExtra($S, " + originalValue + ")") : ("getInt($S)"));
-        } else if (type == TypeKind.LONG.ordinal()) {
-            statement += (isActivity ? ("getLongExtra($S, " + originalValue + ")") : ("getLong($S)"));
-        }else if(type == TypeKind.CHAR.ordinal()){
-            statement += (isActivity ? ("getCharExtra($S, " + originalValue + ")") : ("getChar($S)"));
-        } else if (type == TypeKind.FLOAT.ordinal()) {
-            statement += (isActivity ? ("getFloatExtra($S, " + originalValue + ")") : ("getFloat($S)"));
-        } else if (type == TypeKind.DOUBLE.ordinal()) {
-            statement += (isActivity ? ("getDoubleExtra($S, " + originalValue + ")") : ("getDouble($S)"));
-        } else if (type == TypeKind.STRING.ordinal()) {
-            statement += (isActivity ? ("getStringExtra($S)") : ("getString($S)"));
+    private String buildStatement(String statement, int type, boolean isActivity) {
+        String tempControl = "temp = ";
+        if (type == TypeKind.BOOLEAN.ordinal() ||
+                type == TypeKind.BYTE.ordinal() ||
+                type == TypeKind.INT.ordinal() ||
+                type == TypeKind.LONG.ordinal() ||
+                type == TypeKind.CHAR.ordinal() ||
+                type == TypeKind.SHORT.ordinal() ||
+                type == TypeKind.FLOAT.ordinal() ||
+                type == TypeKind.DOUBLE.ordinal() ||
+                type == TypeKind.STRING.ordinal()) {
+            statement += (isActivity ? ("getSerializableExtra($S)") : ("getSerializable($S)"));
         } else if (type == TypeKind.PARCELABLE.ordinal()) {
             statement += (isActivity ? ("getParcelableExtra($S)") : ("getParcelable($S)"));
-        } else if (type == TypeKind.OBJECT.ordinal()) {
-            statement = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new com.alibaba.android.arouter.facade.model.TypeWrapper<$T>(){}.getType())";
         }
-
-        return statement;
+        return tempControl + statement;
     }
 
     /**

--- a/module-java/build.gradle
+++ b/module-java/build.gradle
@@ -21,8 +21,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/module-kotlin/build.gradle
+++ b/module-kotlin/build.gradle
@@ -26,8 +26,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {


### PR DESCRIPTION
# 主要修改部分：
 
### 1. require为true，且未真正传值时，抛出异常

项目协作开发时，require字段指定为false或者true，可以保证其他人员在向页面跳转时，不会因为缺少字段而出现错误。

之前应该是在某次迭代中删除了抛出异常的功能，改成了输出Log.e日志

当其时抛出异常也不无不可。

### 2. 添加针对包装器类字段都赋值处理。

之前处理数据时针对 **int** 类型可以很好都赋值，但当字段为Integter类型（Kotlin中可空类型较多）时，赋值会发生错误。

这里统一采用了 getSerializableExtra 方式（针对Fragment为getSerializable），获取值若非null，才会进行赋值