### PR TITLE
Update DefaultPoolExecutor.java

### DIFF
--- a/arouter-api/src/main/java/com/alibaba/android/arouter/thread/DefaultPoolExecutor.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/thread/DefaultPoolExecutor.java
@@ -28,7 +28,7 @@ public class DefaultPoolExecutor extends ThreadPoolExecutor {
     private static final int MAX_THREAD_COUNT = INIT_THREAD_COUNT;
     private static final long SURPLUS_THREAD_LIFE = 30L;
 
-    private static DefaultPoolExecutor instance;
+    private static volatile DefaultPoolExecutor instance;
 
     public static DefaultPoolExecutor getInstance() {
         if (null == instance) {


### PR DESCRIPTION
在指令重排序下，单例双重校验不安全，用volatile可以禁止指令重排序