### PR TITLE
fix repeated inject init code when Multi-channel packaging

### DIFF
--- a/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
+++ b/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
@@ -80,7 +80,10 @@ class ScanUtil {
                 if (ext.interfaceName && interfaces != null) {
                     interfaces.each { itName ->
                         if (itName == ext.interfaceName) {
-                            ext.classList.add(name)
+                            //fix repeated inject init code when Multi-channel packaging
+                            if (!ext.classList.contains(name)) {
+                                ext.classList.add(name)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In some cases such as dex hot fix with apk protection,Multi-channel
packaging through execute "gradlew assemble" will lead to repeated
inject init-code,repeated injection
will cause error ,because the dex diff algorithm will diff the class
"com.alibaba.android.arouter.core.LogisticsCenter" when build single
channel dex patch!
