### PR TITLE
fix ARouter.navigation(Class) API to make it more clear.

### DIFF
--- a/arouter-api/src/main/java/com/alibaba/android/arouter/core/LogisticsCenter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/core/LogisticsCenter.java
@@ -215,13 +215,13 @@ public class LogisticsCenter {
      * @param serviceName interfaceName
      * @return postcard
      */
-    public static Postcard buildProvider(String serviceName) {
+    public static <T extends IProvider> Postcard<T> buildProvider(String serviceName) {
         RouteMeta meta = Warehouse.providersIndex.get(serviceName);
 
         if (null == meta) {
             return null;
         } else {
-            return new Postcard(meta.getPath(), meta.getGroup());
+            return new Postcard<>(meta.getPath(), meta.getGroup());
         }
     }
 
@@ -230,7 +230,7 @@ public class LogisticsCenter {
      *
      * @param postcard Incomplete postcard, should complete by this method.
      */
-    public synchronized static void completion(Postcard postcard) {
+    public synchronized static <T extends IProvider> void completion(Postcard<T> postcard) {
         if (null == postcard) {
             throw new NoRouteFoundException(TAG + "No postcard!");
         }
@@ -291,14 +291,14 @@ public class LogisticsCenter {
             switch (routeMeta.getType()) {
                 case PROVIDER:  // if the route is provider, should find its instance
                     // Its provider, so it must implement IProvider
-                    Class<? extends IProvider> providerMeta = (Class<? extends IProvider>) routeMeta.getDestination();
-                    IProvider instance = Warehouse.providers.get(providerMeta);
+                    Class<T> providerMeta = (Class<T>) routeMeta.getDestination();
+                    T instance = Warehouse.getProvider(providerMeta);
                     if (null == instance) { // There's no instance of this provider
-                        IProvider provider;
+                        T provider;
                         try {
                             provider = providerMeta.getConstructor().newInstance();
                             provider.init(mContext);
-                            Warehouse.providers.put(providerMeta, provider);
+                            Warehouse.putProvider(providerMeta, provider);
                             instance = provider;
                         } catch (Exception e) {
                             throw new HandlerException("Init provider failed! " + e.getMessage());

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
@@ -24,7 +24,7 @@ class Warehouse {
     static Map<String, RouteMeta> routes = new HashMap<>();
 
     // Cache provider
-    static Map<Class, IProvider> providers = new HashMap<>();
+    private static Map<Class, IProvider> providers = new HashMap<>();
     static Map<String, RouteMeta> providersIndex = new HashMap<>();
 
     // Cache interceptor
@@ -38,5 +38,13 @@ class Warehouse {
         providersIndex.clear();
         interceptors.clear();
         interceptorsIndex.clear();
+    }
+
+    static <T extends IProvider> void putProvider(Class<T> clazz, T provider) {
+        providers.put(clazz, provider);
+    }
+
+    static <T extends IProvider> T getProvider(Class<T> clazz) {
+        return ((T) providers.get(clazz));
     }
 }

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
@@ -27,14 +27,14 @@ import java.util.ArrayList;
  * @version 1.1.0
  * @since 16/8/22 19:16
  */
-public final class Postcard extends RouteMeta {
+public final class Postcard<T extends IProvider> extends RouteMeta {
     // Base
     private Uri uri;
     private Object tag;             // A tag prepare for some thing wrong.
     private Bundle mBundle;         // Data to transform
     private int flags = -1;         // Flags of route
     private int timeout = 300;      // Navigation timeout, TimeUnit.Second
-    private IProvider provider;     // It will be set value, if this postcard was provider.
+    private T provider;     // It will be set value, if this postcard was provider.
     private boolean greenChannel;
     private SerializationService serializationService;
 
@@ -55,11 +55,11 @@ public final class Postcard extends RouteMeta {
         return exitAnim;
     }
 
-    public IProvider getProvider() {
+    public T getProvider() {
         return provider;
     }
 
-    public Postcard setProvider(IProvider provider) {
+    public Postcard setProvider(T provider) {
         this.provider = provider;
         return this;
     }

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/ARouter.java
@@ -8,6 +8,7 @@ import com.alibaba.android.arouter.exception.InitException;
 import com.alibaba.android.arouter.facade.Postcard;
 import com.alibaba.android.arouter.facade.callback.NavigationCallback;
 import com.alibaba.android.arouter.facade.template.ILogger;
+import com.alibaba.android.arouter.facade.template.IProvider;
 import com.alibaba.android.arouter.utils.Consts;
 
 import java.util.concurrent.ThreadPoolExecutor;
@@ -168,7 +169,7 @@ public final class ARouter {
      * @param <T>     return type
      * @return instance of service
      */
-    public <T> T navigation(Class<? extends T> service) {
+    public <T extends IProvider> T navigation(Class<? extends T> service) {
         return _ARouter.getInstance().navigation(service);
     }
 

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
@@ -25,6 +25,7 @@ import com.alibaba.android.arouter.facade.service.DegradeService;
 import com.alibaba.android.arouter.facade.service.InterceptorService;
 import com.alibaba.android.arouter.facade.service.PathReplaceService;
 import com.alibaba.android.arouter.facade.template.ILogger;
+import com.alibaba.android.arouter.facade.template.IProvider;
 import com.alibaba.android.arouter.thread.DefaultPoolExecutor;
 import com.alibaba.android.arouter.utils.Consts;
 import com.alibaba.android.arouter.utils.DefaultLogger;
@@ -244,9 +245,9 @@ final class _ARouter {
         interceptorService = (InterceptorService) ARouter.getInstance().build("/arouter/service/interceptor").navigation();
     }
 
-    protected <T> T navigation(Class<? extends T> service) {
+    protected <T extends IProvider> T navigation(Class<? extends T> service) {
         try {
-            Postcard postcard = LogisticsCenter.buildProvider(service.getName());
+            Postcard<T> postcard = LogisticsCenter.buildProvider(service.getName());
 
             // Compatible 1.0.5 compiler sdk.
             // Earlier versions did not use the fully qualified name to get the service
@@ -260,7 +261,7 @@ final class _ARouter {
             }
 
             LogisticsCenter.completion(postcard);
-            return (T) postcard.getProvider();
+            return postcard.getProvider();
         } catch (NoRouteFoundException ex) {
             logger.warning(Consts.TAG, ex.getMessage());
             return null;


### PR DESCRIPTION
the current definition is

```java
public <T> T navigation(Class<? extends T> service) {
    return _ARouter.getInstance().navigation(service);
}
```

The `T` should in fact extends `IProvider`. I add this to make it clear to developers about what `T` they should write.

Other changes clearify the relationship each class and `IProvider`.