### PR TITLE
support same group name across modules, 支持在不同的module中采用相同的group名

### DIFF
--- a/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/core/Warehouse.java
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 class Warehouse {
     // Cache route and metas
-    static Map<String, Class<? extends IRouteGroup>> groupsIndex = new HashMap<>();
+    static Map<String, List<Class<? extends IRouteGroup>>> groupsIndex = new HashMap<>();
     static Map<String, RouteMeta> routes = new HashMap<>();
 
     // Cache provider

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/IRouteRoot.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/template/IRouteRoot.java
@@ -1,5 +1,6 @@
 package com.alibaba.android.arouter.facade.template;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -15,5 +16,5 @@ public interface IRouteRoot {
      * Load routes to input
      * @param routes input
      */
-    void loadInto(Map<String, Class<? extends IRouteGroup>> routes);
+    void loadInto(Map<String, List<Class<? extends IRouteGroup>>> routes);
 }


### PR DESCRIPTION
i think it's a lot convenient to have same group name across modules.
such as :business:business-pay and :business:business-login can have same group name business, thus they can have a path like /business/pay and /business/login.