### PR TITLE
fix:解决android tool 3.6.0以上的环境，当依赖库的代码发生变化，增量编译会出现 DexArchiveMergerException 的问题

### DIFF
--- a/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/core/RegisterTransform.groovy
+++ b/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/core/RegisterTransform.groovy
@@ -67,6 +67,10 @@ class RegisterTransform extends Transform {
         long startTime = System.currentTimeMillis()
         boolean leftSlash = File.separator == '/'
 
+        if (!isIncremental){
+            outputProvider.deleteAll()
+        }
+
         inputs.each { TransformInput input ->
 
             // scan all jars


### PR DESCRIPTION
复现步骤

1. app工程 添加依赖库 implementation 'com.squareup.okio:okio:2.7.0'    然后编译一次
2.  com.squareup.okio:okio:2.7.0 改为 com.squareup.okio:okio:2.8.0 版本再次编译
此时会报
om.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives: 
Type okio.-DeflaterSinkExtensions is defined multiple times: 
![image](https://user-images.githubusercontent.com/11730925/98355914-c68b5700-205d-11eb-9caa-c1e5f6ad5d1e.png)

并且在 build/intermediates/mixed_scope_dex_archive/ 路径下确实会发现上次编译的产物没有被删除干净.

代码改正后，就没有这个问题了。
