### PR TITLE
Fixed the incremental invalidation of the annotation processor

### DIFF
--- a/arouter-compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/arouter-compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,3 +1,3 @@
-com.alibaba.android.arouter.compiler.processor.RouteProcessor,isolating
-com.alibaba.android.arouter.compiler.processor.AutowiredProcessor,isolating
-com.alibaba.android.arouter.compiler.processor.InterceptorProcessor,isolating
+com.alibaba.android.arouter.compiler.processor.RouteProcessor,aggregating
+com.alibaba.android.arouter.compiler.processor.AutowiredProcessor,aggregating
+com.alibaba.android.arouter.compiler.processor.InterceptorProcessor,aggregating


### PR DESCRIPTION
致Arouter开发组:
当前`Arouter`并不属于 `isolating`类型的增量型注解处理器.
`ioslating`:有一条限制,一个注解映射一个单独的文件,不可多个注解映射单个文件.
在`RouteProcessor`中会将多个@Route归并到一个文件,违反了`isolating`规定.且没有给文件传入 `originating element`.

[官方文档链接](https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_compile)

![image](https://user-images.githubusercontent.com/22413240/116774998-e2166e00-aa92-11eb-99ba-53346d60d983.png)

你可以仔细看到gradle编译过程的抛出的异常信息:
![image](https://user-images.githubusercontent.com/22413240/116774881-2f461000-aa92-11eb-9092-c38f3b2cb467.png)

`Arouter`所使用的处理器都属于`aggregating`类型增量注解处理器.


此`PR`经过本文严格测试发现编译时有效.

下面给出一个复现问题步骤:

我们以`module-kotlin`模块为例

1. 运行gradle命令:`:app:compileDebugJavaWithJavac`

2. module-kotlin/build/generated/source/kapt 文件下会生成对应的文件

3. 注释掉`TestNormalActivity`对应@Route(path = "/kotlin/java")

```java

//注释以下代码检测是否增量
//@Route(path = "/kotlin/java")
public class TestNormalActivity extends AppCompatActivity {

}

```

4. 运行gradle命令:`:app:compileDebugJavaWithJavac`
5.  `module-kotlin/build/generated/source/kapt`这个文件夹会整个全部删除重建,证明增量失败

---

当前版本如果修改对应`Arouter`相关类会将其他库的文件一起删除重建(如Dagger生成的文件),这将给大型工程带来巨大的编译时效问题.
拉取PR后您可按上述步骤进行实际校验是否有效.另外当您拉取PR后,请删除所有build文件夹在测试,因为gradle存在一个bug,如果之前存在非增量的环境,现在变成了增量环境也是非增量的.相关[gradle issue ](https://github.com/gradle/gradle/issues/17034).

由于我所在的工程存在大量apt模块,所以每次改动`Arouter`相关代码将带来不可小觑的编译时间问题.为了解决这个问题,我不得以clone后在内网发布另一个版本,但是随着`Arouter`的迭代,我也要跟着拉取合并.

