### PR TITLE
1. 添加多路由支持，同一个页面 or service 添加多个路由路径

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     signingConfigs {

--- a/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
@@ -244,6 +244,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                         .withObject("objList", objList)
                         .withObject("map", map).navigation(this);
                 break;
+            case R.id.route1:
+                ARouter.getInstance().build("/module/1").navigation();
+                break;
+            case R.id.route2:
+                ARouter.getInstance().build("/test/multiRoute").navigation();
+                break;
+
             default:
                 break;
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -289,5 +289,33 @@
                 android:onClick="onClick"
                 android:text="动态路由测试" />
         </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/between_cell"
+            android:background="@drawable/bg_test_area"
+            android:orientation="vertical"
+            android:padding="@dimen/test_area_padding">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="多路由（同一个页面 or service 指定多个路由）" />
+
+            <Button
+                android:id="@+id/route1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:onClick="onClick"
+                android:text="用路由1跳转" />
+
+            <Button
+                android:id="@+id/route2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:onClick="onClick"
+                android:text="用路由2跳转" />
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/arouter-annotation/src/main/java/com/alibaba/android/arouter/facade/annotation/Route.java
+++ b/arouter-annotation/src/main/java/com/alibaba/android/arouter/facade/annotation/Route.java
@@ -1,6 +1,7 @@
 package com.alibaba.android.arouter.facade.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -12,6 +13,7 @@ import java.lang.annotation.Target;
  * @version 1.0
  * @since 16/8/15 下午9:29
  */
+@Repeatable(Routes.class)
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface Route {

--- a/arouter-annotation/src/main/java/com/alibaba/android/arouter/facade/annotation/Routes.java
+++ b/arouter-annotation/src/main/java/com/alibaba/android/arouter/facade/annotation/Routes.java
@@ -1,0 +1,12 @@
+package com.alibaba.android.arouter.facade.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface Routes {
+    Route[] value();
+}

--- a/arouter-compiler/build.gradle
+++ b/arouter-compiler/build.gradle
@@ -6,7 +6,7 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.alibaba:arouter-annotation:1.0.6'
+    implementation project(':arouter-annotation')
 
     annotationProcessor 'com.google.auto.service:auto-service:1.0-rc7'
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0-rc7'

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
@@ -81,5 +81,6 @@ public class Consts {
     // Annotation type
     public static final String ANNOTATION_TYPE_INTECEPTOR = FACADE_PACKAGE + ".annotation.Interceptor";
     public static final String ANNOTATION_TYPE_ROUTE = FACADE_PACKAGE + ".annotation.Route";
+    public static final String ANNOTATION_TYPE_ROUTES = FACADE_PACKAGE + ".annotation.Routes";
     public static final String ANNOTATION_TYPE_AUTOWIRED = FACADE_PACKAGE + ".annotation.Autowired";
 }

--- a/module-java/build.gradle
+++ b/module-java/build.gradle
@@ -26,8 +26,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/TestModuleActivity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/TestModuleActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import com.alibaba.android.arouter.facade.annotation.Route;
 
 @Route(path = "/module/1")
+@Route(path = "/test/multiRoute")
 public class TestModuleActivity extends Activity {
 
     @Override


### PR DESCRIPTION
#### 功能：添加多路由支持，同一个页面 or service 添加多个路由路径

##### 适用场景：
  1. ios & andorid 由于历史原因定义的路由不一致，想要进行统一路由的时候，又需要兼容老的路由地址，可通过多路由地址解决
  2. 其他...
  
##### 使用方式：
1. 直接在activity或其他Arouter支持的类上添加多个@Route注解，如：

```
@Route(path = "/module/1")
@Route(path = "/test/multiRoute")
public class TestModuleActivity extends Activity {
   ...
}
```

##### 环境要求
1. 需要jvm配置成1.8，参考

```
compileJava {
    sourceCompatibility = '1.8'
    targetCompatibility = '1.8'
}

```