### PR TITLE
fix: address 1.5.3 correctness issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           ./gradlew --no-daemon --stacktrace -Parouter.useLocalRegisterPlugin
           :arouter-annotation:build
           :arouter-compiler:build
+          :arouter-api:testDebugUnitTest
           :arouter-api:assemble
           assembleDebug
 

--- a/arouter-api/build.gradle
+++ b/arouter-api/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     annotationProcessor 'com.alibaba:arouter-compiler:1.5.2'
     api 'com.alibaba:arouter-annotation:1.0.6'
     implementation "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:3.12.4'
 }
 
 apply from: rootProject.file('gradle/publish.gradle')

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
@@ -282,14 +282,16 @@ final class _ARouter {
      * @param callback    cb
      */
     protected Object navigation(final Context context, final Postcard postcard, final int requestCode, final NavigationCallback callback) {
+        final Context currentContext = resolveNavigationContext(context, mContext);
+
         PretreatmentService pretreatmentService = ARouter.getInstance().navigation(PretreatmentService.class);
-        if (null != pretreatmentService && !pretreatmentService.onPretreatment(context, postcard)) {
+        if (null != pretreatmentService && !pretreatmentService.onPretreatment(currentContext, postcard)) {
             // Pretreatment failed, navigation canceled.
             return null;
         }
 
-        // Set context to postcard.
-        postcard.setContext(null == context ? mContext : context);
+        // Pretreatment and the actual navigation must observe the same effective context.
+        postcard.setContext(currentContext);
 
         try {
             LogisticsCenter.completion(postcard);
@@ -356,6 +358,10 @@ final class _ARouter {
         }
 
         return null;
+    }
+
+    static Context resolveNavigationContext(Context context, Context applicationContext) {
+        return null == context ? applicationContext : context;
     }
 
     private Object _navigation(final Postcard postcard, final int requestCode, final NavigationCallback callback) {

--- a/arouter-api/src/test/java/com/alibaba/android/arouter/launcher/NavigationContextTest.java
+++ b/arouter-api/src/test/java/com/alibaba/android/arouter/launcher/NavigationContextTest.java
@@ -1,0 +1,26 @@
+package com.alibaba.android.arouter.launcher;
+
+import android.content.Context;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+public class NavigationContextTest {
+
+    @Test
+    public void usesApplicationContextWhenCallerDoesNotProvideOne() {
+        Context applicationContext = mock(Context.class);
+
+        assertSame(applicationContext, _ARouter.resolveNavigationContext(null, applicationContext));
+    }
+
+    @Test
+    public void preservesExplicitNavigationContext() {
+        Context applicationContext = mock(Context.class);
+        Context activityContext = mock(Context.class);
+
+        assertSame(activityContext, _ARouter.resolveNavigationContext(activityContext, applicationContext));
+    }
+}

--- a/arouter-compiler/build.gradle
+++ b/arouter-compiler/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation("com.google.code.gson:gson:$gson_version") {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.testing.compile:compile-testing:0.21.0'
 }
 
 apply from: rootProject.file('gradle/publish.gradle')

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/AutowiredProcessor.java
@@ -8,7 +8,6 @@ import com.alibaba.android.arouter.facade.annotation.Autowired;
 import com.alibaba.android.arouter.facade.enums.TypeKind;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -30,7 +29,6 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -52,6 +50,8 @@ public class AutowiredProcessor extends BaseProcessor {
     private Map<TypeElement, List<Element>> parentAndChild = new HashMap<>();   // Contain field need autowired and his super class.
     private static final ClassName ARouterClass = ClassName.get("com.alibaba.android.arouter.launcher", "ARouter");
     private static final ClassName AndroidLog = ClassName.get("android.util", "Log");
+    private static final ClassName AndroidBundle = ClassName.get("android.os", "Bundle");
+    private static final ClassName TypeWrapperClass = ClassName.get("com.alibaba.android.arouter.facade.model", "TypeWrapper");
 
     @Override
     public synchronized void init(ProcessingEnvironment processingEnvironment) {
@@ -80,10 +80,11 @@ public class AutowiredProcessor extends BaseProcessor {
     private void generateHelper() throws IOException, IllegalAccessException {
         TypeElement type_ISyringe = elementUtils.getTypeElement(ISYRINGE);
         TypeElement type_JsonService = elementUtils.getTypeElement(JSON_SERVICE);
-        TypeMirror iProvider = elementUtils.getTypeElement(Consts.IPROVIDER).asType();
-        TypeMirror activityTm = elementUtils.getTypeElement(Consts.ACTIVITY).asType();
-        TypeMirror fragmentTm = elementUtils.getTypeElement(Consts.FRAGMENT).asType();
-        TypeMirror fragmentTmV4 = elementUtils.getTypeElement(Consts.FRAGMENT_V4).asType();
+        TypeMirror iProvider = getTypeMirror(Consts.IPROVIDER);
+        TypeMirror activityTm = getTypeMirror(Consts.ACTIVITY);
+        TypeMirror fragmentTm = getTypeMirror(Consts.FRAGMENT);
+        TypeMirror fragmentTmV4 = getTypeMirror(Consts.FRAGMENT_V4);
+        TypeMirror fragmentTmAndroidX = getTypeMirror(Consts.FRAGMENT_ANDROIDX);
 
         // Build input param name.
         ParameterSpec objectParamSpec = ParameterSpec.builder(TypeName.OBJECT, "target").build();
@@ -116,11 +117,35 @@ public class AutowiredProcessor extends BaseProcessor {
                 injectMethodBuilder.addStatement("serializationService = $T.getInstance().navigation($T.class)", ARouterClass, ClassName.get(type_JsonService));
                 injectMethodBuilder.addStatement("$T substitute = ($T)target", ClassName.get(parent), ClassName.get(parent));
 
+                boolean hasAutowiredValues = false;
+                for (Element element : childs) {
+                    if (!isSubtypeOf(element.asType(), iProvider)) {
+                        hasAutowiredValues = true;
+                        break;
+                    }
+                }
+
+                if (hasAutowiredValues) {
+                    if (isSubtypeOf(parent.asType(), activityTm)) {
+                        injectMethodBuilder.addStatement(
+                                "$T bundle = substitute.getIntent() == null ? null : substitute.getIntent().getExtras()",
+                                AndroidBundle
+                        );
+                    } else if (isSubtypeOf(parent.asType(), fragmentTm)
+                            || isSubtypeOf(parent.asType(), fragmentTmV4)
+                            || isSubtypeOf(parent.asType(), fragmentTmAndroidX)) {
+                        injectMethodBuilder.addStatement("$T bundle = substitute.getArguments()", AndroidBundle);
+                    } else {
+                        throw new IllegalAccessException("The fields need autowired from intent, its parent must be activity or fragment! ["
+                                + parent.getQualifiedName() + "]");
+                    }
+                }
+
                 // Generate method body, start inject.
                 for (Element element : childs) {
                     Autowired fieldConfig = element.getAnnotation(Autowired.class);
                     String fieldName = element.getSimpleName().toString();
-                    if (types.isSubtype(element.asType(), iProvider)) {  // It's provider
+                    if (isSubtypeOf(element.asType(), iProvider)) {  // It's provider
                         if ("".equals(fieldConfig.name())) {    // User has not set service path, then use byType.
 
                             // Getter
@@ -147,33 +172,41 @@ public class AutowiredProcessor extends BaseProcessor {
                             injectMethodBuilder.endControlFlow();
                         }
                     } else {    // It's normal intent value
-                        String originalValue = "substitute." + fieldName;
-                        String statement = "substitute." + fieldName + " = " + buildCastCode(element) + "substitute.";
-                        boolean isActivity = false;
-                        if (types.isSubtype(parent.asType(), activityTm)) {  // Activity, then use getIntent()
-                            isActivity = true;
-                            statement += "getIntent().";
-                        } else if (types.isSubtype(parent.asType(), fragmentTm) || types.isSubtype(parent.asType(), fragmentTmV4)) {   // Fragment, then use getArguments()
-                            statement += "getArguments().";
-                        } else {
-                            throw new IllegalAccessException("The field [" + fieldName + "] need autowired from intent, its parent must be activity or fragment!");
-                        }
+                        String paramName = StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name();
+                        int type = typeUtils.typeExchange(element);
 
-                        statement = buildStatement(originalValue, statement, typeUtils.typeExchange(element), isActivity, isKtClass(parent));
-                        if (statement.startsWith("serializationService.")) {   // Not mortals
+                        injectMethodBuilder.beginControlFlow("if (null != bundle && bundle.containsKey($S))", paramName);
+                        if (type == TypeKind.OBJECT.ordinal()) {
                             injectMethodBuilder.beginControlFlow("if (null != serializationService)");
+                            TypeName fieldType = TypeName.get(element.asType());
+                            String valueName = fieldName + "Value";
                             injectMethodBuilder.addStatement(
-                                    "substitute." + fieldName + " = " + statement,
-                                    (StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name()),
-                                    ClassName.get(element.asType())
+                                    "$T " + valueName + " = serializationService.parseObject(bundle.getString($S), new $T<$T>(){}.getType())",
+                                    fieldType,
+                                    paramName,
+                                    TypeWrapperClass,
+                                    fieldType
                             );
+                            injectMethodBuilder.beginControlFlow("if (null != " + valueName + ")");
+                            injectMethodBuilder.addStatement("substitute." + fieldName + " = " + valueName);
+                            injectMethodBuilder.endControlFlow();
                             injectMethodBuilder.nextControlFlow("else");
                             injectMethodBuilder.addStatement(
                                     "$T.e(\"" + Consts.TAG + "\", \"You want automatic inject the field '" + fieldName + "' in class '$T' , then you should implement 'SerializationService' to support object auto inject!\")", AndroidLog, ClassName.get(parent));
                             injectMethodBuilder.endControlFlow();
+                        } else if (element.asType().getKind().isPrimitive()) {
+                            injectMethodBuilder.addStatement(
+                                    "substitute." + fieldName + " = bundle." + getBundleGetter(type) + "($S, substitute." + fieldName + ")",
+                                    paramName
+                            );
                         } else {
-                            injectMethodBuilder.addStatement(statement, StringUtils.isEmpty(fieldConfig.name()) ? fieldName : fieldConfig.name());
+                            injectMethodBuilder.addStatement(
+                                    "substitute." + fieldName + " = ($T) bundle.get($S)",
+                                    TypeName.get(element.asType()),
+                                    paramName
+                            );
                         }
+                        injectMethodBuilder.endControlFlow();
 
                         // Validator
                         if (fieldConfig.required() && !element.asType().getKind().isPrimitive()) {  // Primitive wont be check.
@@ -197,67 +230,27 @@ public class AutowiredProcessor extends BaseProcessor {
         }
     }
 
-    private boolean isKtClass(Element element) {
-        for (AnnotationMirror annotationMirror : elementUtils.getAllAnnotationMirrors(element)) {
-            if (annotationMirror.getAnnotationType().toString().contains("kotlin")) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private String buildCastCode(Element element) {
-        if (typeUtils.typeExchange(element) == TypeKind.SERIALIZABLE.ordinal()) {
-            return CodeBlock.builder().add("($T) ", ClassName.get(element.asType())).build().toString();
-        }
-        return "";
-    }
-
-    /**
-     * Build param inject statement
-     */
-    private String buildStatement(String originalValue, String statement, int type, boolean isActivity, boolean isKt) {
+    private String getBundleGetter(int type) {
         switch (TypeKind.values()[type]) {
             case BOOLEAN:
-                statement += "getBoolean" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getBoolean";
             case BYTE:
-                statement += "getByte" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getByte";
             case SHORT:
-                statement += "getShort" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getShort";
             case INT:
-                statement += "getInt" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getInt";
             case LONG:
-                statement += "getLong" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getLong";
             case CHAR:
-                statement += "getChar" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getChar";
             case FLOAT:
-                statement += "getFloat" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
+                return "getFloat";
             case DOUBLE:
-                statement += "getDouble" + (isActivity ? "Extra" : "") + "($S, " + originalValue + ")";
-                break;
-            case STRING:
-                statement += (isActivity ? ("getExtras() == null ? " + originalValue + " : substitute.getIntent().getExtras().getString($S") : ("getString($S")) + ", " + originalValue + ")";
-                break;
-            case SERIALIZABLE:
-                statement += (isActivity ? ("getSerializableExtra($S)") : ("getSerializable($S)"));
-                break;
-            case PARCELABLE:
-                statement += (isActivity ? ("getParcelableExtra($S)") : ("getParcelable($S)"));
-                break;
-            case OBJECT:
-                statement = "serializationService.parseObject(substitute." + (isActivity ? "getIntent()." : "getArguments().") + (isActivity ? "getStringExtra($S)" : "getString($S)") + ", new " + TYPE_WRAPPER + "<$T>(){}.getType())";
-                break;
+                return "getDouble";
+            default:
+                throw new IllegalArgumentException("Unsupported primitive type: " + TypeKind.values()[type]);
         }
-
-        return statement;
     }
 
     /**

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/BaseProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/BaseProcessor.java
@@ -9,6 +9,8 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.util.HashSet;
@@ -74,5 +76,17 @@ public abstract class BaseProcessor extends AbstractProcessor {
             this.add(KEY_MODULE_NAME);
             this.add(KEY_GENERATE_DOC_NAME);
         }};
+    }
+
+    /**
+     * Resolve a type that may not be present on the consuming module's classpath.
+     */
+    TypeMirror getTypeMirror(String className) {
+        TypeElement element = elementUtils.getTypeElement(className);
+        return element == null ? null : element.asType();
+    }
+
+    boolean isSubtypeOf(TypeMirror type, TypeMirror parent) {
+        return parent != null && types.isSubtype(type, parent);
     }
 }

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/processor/RouteProcessor.java
@@ -82,7 +82,7 @@ public class RouteProcessor extends BaseProcessor {
     public synchronized void init(ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
 
-        iProvider = elementUtils.getTypeElement(Consts.IPROVIDER).asType();
+        iProvider = getTypeMirror(Consts.IPROVIDER);
 
         logger.info(">>> RouteProcessor init. <<<");
     }
@@ -134,10 +134,11 @@ public class RouteProcessor extends BaseProcessor {
 
             rootMap.clear();
 
-            TypeMirror type_Activity = elementUtils.getTypeElement(ACTIVITY).asType();
-            TypeMirror type_Service = elementUtils.getTypeElement(SERVICE).asType();
-            TypeMirror fragmentTm = elementUtils.getTypeElement(FRAGMENT).asType();
-            TypeMirror fragmentTmV4 = elementUtils.getTypeElement(Consts.FRAGMENT_V4).asType();
+            TypeMirror type_Activity = getTypeMirror(ACTIVITY);
+            TypeMirror type_Service = getTypeMirror(SERVICE);
+            TypeMirror fragmentTm = getTypeMirror(FRAGMENT);
+            TypeMirror fragmentTmV4 = getTypeMirror(Consts.FRAGMENT_V4);
+            TypeMirror fragmentTmAndroidX = getTypeMirror(Consts.FRAGMENT_ANDROIDX);
 
             // Interface of ARouter
             TypeElement type_IRouteGroup = elementUtils.getTypeElement(IROUTE_GROUP);
@@ -191,27 +192,31 @@ public class RouteProcessor extends BaseProcessor {
                 RouteMeta routeMeta;
 
                 // Activity or Fragment
-                if (types.isSubtype(tm, type_Activity) || types.isSubtype(tm, fragmentTm) || types.isSubtype(tm, fragmentTmV4)) {
+                boolean isActivity = isSubtypeOf(tm, type_Activity);
+                boolean isFragment = isSubtypeOf(tm, fragmentTm)
+                        || isSubtypeOf(tm, fragmentTmV4)
+                        || isSubtypeOf(tm, fragmentTmAndroidX);
+                if (isActivity || isFragment) {
                     // Get all fields annotation by @Autowired
                     Map<String, Integer> paramsType = new HashMap<>();
                     Map<String, Autowired> injectConfig = new HashMap<>();
                     injectParamCollector(element, paramsType, injectConfig);
 
-                    if (types.isSubtype(tm, type_Activity)) {
+                    if (isActivity) {
                         // Activity
                         logger.info(">>> Found activity route: " + tm.toString() + " <<<");
                         routeMeta = new RouteMeta(route, element, RouteType.ACTIVITY, paramsType);
                     } else {
                         // Fragment
                         logger.info(">>> Found fragment route: " + tm.toString() + " <<<");
-                        routeMeta = new RouteMeta(route, element, RouteType.parse(FRAGMENT), paramsType);
+                        routeMeta = new RouteMeta(route, element, RouteType.FRAGMENT, paramsType);
                     }
 
                     routeMeta.setInjectConfig(injectConfig);
-                } else if (types.isSubtype(tm, iProvider)) {         // IProvider
+                } else if (isSubtypeOf(tm, iProvider)) {         // IProvider
                     logger.info(">>> Found provider route: " + tm.toString() + " <<<");
                     routeMeta = new RouteMeta(route, element, RouteType.PROVIDER, null);
-                } else if (types.isSubtype(tm, type_Service)) {           // Service
+                } else if (isSubtypeOf(tm, type_Service)) {           // Service
                     logger.info(">>> Found service route: " + tm.toString() + " <<<");
                     routeMeta = new RouteMeta(route, element, RouteType.parse(SERVICE), null);
                 } else {

--- a/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
+++ b/arouter-compiler/src/main/java/com/alibaba/android/arouter/compiler/utils/Consts.java
@@ -27,6 +27,7 @@ public class Consts {
     public static final String ACTIVITY = "android.app.Activity";
     public static final String FRAGMENT = "android.app.Fragment";
     public static final String FRAGMENT_V4 = "android.support.v4.app.Fragment";
+    public static final String FRAGMENT_ANDROIDX = "androidx.fragment.app.Fragment";
     public static final String SERVICE = "android.app.Service";
     public static final String PARCELABLE = "android.os.Parcelable";
 

--- a/arouter-compiler/src/test/java/com/alibaba/android/arouter/compiler/processor/ProcessorRegressionTest.java
+++ b/arouter-compiler/src/test/java/com/alibaba/android/arouter/compiler/processor/ProcessorRegressionTest.java
@@ -1,0 +1,161 @@
+package com.alibaba.android.arouter.compiler.processor;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.tools.JavaFileObject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProcessorRegressionTest {
+
+    @Test
+    public void routeProcessorSupportsAndroidXWithoutLegacySupportFragment() throws Exception {
+        List<JavaFileObject> sources = commonSources();
+        sources.add(JavaFileObjects.forSourceLines(
+                "test.AndroidXRoute",
+                "package test;",
+                "import com.alibaba.android.arouter.facade.annotation.Route;",
+                "@Route(path = \"/test/androidx\")",
+                "public class AndroidXRoute extends androidx.fragment.app.Fragment {}"
+        ));
+
+        Compilation compilation = Compiler.javac()
+                .withOptions("-AAROUTER_MODULE_NAME=test")
+                .withProcessors(new RouteProcessor())
+                .compile(sources);
+
+        assertEquals(compilation.toString(), Compilation.Status.SUCCESS, compilation.status());
+        assertTrue(generatedSource(compilation, "ARouter$$Group$$test.java")
+                .contains("RouteType.FRAGMENT"));
+    }
+
+    @Test
+    public void autowiredProcessorGuardsMissingContainersAndNullableValues() throws Exception {
+        List<JavaFileObject> sources = commonSources();
+        sources.add(JavaFileObjects.forSourceLines(
+                "test.InjectionTarget",
+                "package test;",
+                "import com.alibaba.android.arouter.facade.annotation.Autowired;",
+                "public class InjectionTarget extends android.app.Activity {",
+                "  @Autowired public int count = 7;",
+                "  @Autowired public Integer nullableCount = null;",
+                "  @Autowired public String title = \"default\";",
+                "  @Autowired public Payload payload = new Payload();",
+                "}",
+                "class Payload {}"
+        ));
+        sources.add(JavaFileObjects.forSourceLines(
+                "test.AndroidXInjectionTarget",
+                "package test;",
+                "import com.alibaba.android.arouter.facade.annotation.Autowired;",
+                "public class AndroidXInjectionTarget extends androidx.fragment.app.Fragment {",
+                "  @Autowired public String title = \"default\";",
+                "}"
+        ));
+
+        Compilation compilation = Compiler.javac()
+                .withOptions("-AAROUTER_MODULE_NAME=test")
+                .withProcessors(new AutowiredProcessor())
+                .compile(sources);
+
+        assertEquals(compilation.toString(), Compilation.Status.SUCCESS, compilation.status());
+
+        String activityHelper = generatedSource(compilation, "InjectionTarget$$ARouter$$Autowired.java");
+        assertTrue(activityHelper.contains(
+                "Bundle bundle = substitute.getIntent() == null ? null : substitute.getIntent().getExtras();"));
+        assertTrue(activityHelper.contains("if (null != bundle && bundle.containsKey(\"count\"))"));
+        assertTrue(activityHelper.contains("bundle.getInt(\"count\", substitute.count)"));
+        assertTrue(activityHelper.contains("substitute.nullableCount = (Integer) bundle.get(\"nullableCount\")"));
+        assertTrue(activityHelper.contains("Payload payloadValue ="));
+        assertTrue(activityHelper.contains("if (null != payloadValue)"));
+
+        String fragmentHelper = generatedSource(compilation, "AndroidXInjectionTarget$$ARouter$$Autowired.java");
+        assertTrue(fragmentHelper.contains("Bundle bundle = substitute.getArguments();"));
+        assertTrue(fragmentHelper.contains("if (null != bundle && bundle.containsKey(\"title\"))"));
+    }
+
+    private static String generatedSource(Compilation compilation, String fileName) throws IOException {
+        for (JavaFileObject source : compilation.generatedSourceFiles()) {
+            if (source.getName().endsWith(fileName)) {
+                return source.getCharContent(false).toString();
+            }
+        }
+        throw new AssertionError("Generated source not found: " + fileName + "\n" + compilation);
+    }
+
+    private static List<JavaFileObject> commonSources() {
+        return new ArrayList<>(Arrays.asList(
+                source("android.content.Context", "public class Context {}"),
+                source("android.content.Intent",
+                        "public class Intent { public android.os.Bundle getExtras() { return null; } }"),
+                source("android.os.Parcelable", "public interface Parcelable {}"),
+                source("android.os.Bundle",
+                        "public class Bundle {",
+                        "  public boolean containsKey(String key) { return false; }",
+                        "  public Object get(String key) { return null; }",
+                        "  public String getString(String key) { return null; }",
+                        "  public boolean getBoolean(String key, boolean value) { return value; }",
+                        "  public byte getByte(String key, byte value) { return value; }",
+                        "  public short getShort(String key, short value) { return value; }",
+                        "  public int getInt(String key, int value) { return value; }",
+                        "  public long getLong(String key, long value) { return value; }",
+                        "  public char getChar(String key, char value) { return value; }",
+                        "  public float getFloat(String key, float value) { return value; }",
+                        "  public double getDouble(String key, double value) { return value; }",
+                        "}"),
+                source("android.app.Activity",
+                        "public class Activity extends android.content.Context {",
+                        "  public android.content.Intent getIntent() { return null; }",
+                        "}"),
+                source("android.app.Service", "public class Service extends android.content.Context {}"),
+                source("android.app.Fragment",
+                        "public class Fragment { public android.os.Bundle getArguments() { return null; } }"),
+                source("androidx.fragment.app.Fragment",
+                        "public class Fragment { public android.os.Bundle getArguments() { return null; } }"),
+                source("android.util.Log", "public class Log { public static int e(String tag, String message) { return 0; } }"),
+                source("com.alibaba.android.arouter.facade.template.IProvider", "public interface IProvider {}"),
+                source("com.alibaba.android.arouter.facade.template.ISyringe",
+                        "public interface ISyringe { void inject(Object target); }"),
+                source("com.alibaba.android.arouter.facade.template.IRouteGroup",
+                        "public interface IRouteGroup {",
+                        "  void loadInto(java.util.Map<String, com.alibaba.android.arouter.facade.model.RouteMeta> routes);",
+                        "}"),
+                source("com.alibaba.android.arouter.facade.template.IRouteRoot",
+                        "public interface IRouteRoot {",
+                        "  void loadInto(java.util.Map<String, Class<? extends IRouteGroup>> routes);",
+                        "}"),
+                source("com.alibaba.android.arouter.facade.template.IProviderGroup",
+                        "public interface IProviderGroup {",
+                        "  void loadInto(java.util.Map<String, com.alibaba.android.arouter.facade.model.RouteMeta> providers);",
+                        "}"),
+                source("com.alibaba.android.arouter.facade.service.SerializationService",
+                        "public interface SerializationService extends com.alibaba.android.arouter.facade.template.IProvider {",
+                        "  <T> T parseObject(String input, java.lang.reflect.Type type);",
+                        "}"),
+                source("com.alibaba.android.arouter.launcher.ARouter",
+                        "public final class ARouter {",
+                        "  private static final ARouter INSTANCE = new ARouter();",
+                        "  public static ARouter getInstance() { return INSTANCE; }",
+                        "  public <T> T navigation(Class<? extends T> service) { return null; }",
+                        "}")
+        ));
+    }
+
+    private static JavaFileObject source(String name, String... body) {
+        List<String> lines = new ArrayList<>();
+        int packageSeparator = name.lastIndexOf('.');
+        lines.add("package " + name.substring(0, packageSeparator) + ";");
+        lines.addAll(Arrays.asList(body));
+        return JavaFileObjects.forSourceLines(name, lines);
+    }
+}

--- a/arouter-gradle-plugin/build.gradle
+++ b/arouter-gradle-plugin/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     compileOnly "com.android.tools.build:gradle:${rootProject.ext.android_gradle_plugin_version}"
 
     implementation 'org.ow2.asm:asm:7.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 apply from: rootProject.file('gradle/publish.gradle')

--- a/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
+++ b/arouter-gradle-plugin/src/main/groovy/com/alibaba/android/arouter/register/utils/ScanUtil.groovy
@@ -29,7 +29,7 @@ class ScanUtil {
             while (enumeration.hasMoreElements()) {
                 JarEntry jarEntry = (JarEntry) enumeration.nextElement()
                 String entryName = jarEntry.getName()
-                if (entryName.startsWith(ScanSetting.ROUTER_CLASS_PACKAGE_NAME)) {
+                if (!jarEntry.isDirectory() && shouldProcessClass(entryName)) {
                     InputStream inputStream = file.getInputStream(jarEntry)
                     scanClass(inputStream)
                     inputStream.close()
@@ -48,7 +48,9 @@ class ScanUtil {
     }
 
     static boolean shouldProcessClass(String entryName) {
-        return entryName != null && entryName.startsWith(ScanSetting.ROUTER_CLASS_PACKAGE_NAME)
+        return entryName != null &&
+                entryName.startsWith(ScanSetting.ROUTER_CLASS_PACKAGE_NAME) &&
+                entryName.endsWith('.class')
     }
 
     /**

--- a/arouter-gradle-plugin/src/test/groovy/com/alibaba/android/arouter/register/utils/ScanUtilTest.groovy
+++ b/arouter-gradle-plugin/src/test/groovy/com/alibaba/android/arouter/register/utils/ScanUtilTest.groovy
@@ -1,0 +1,43 @@
+package com.alibaba.android.arouter.register.utils
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class ScanUtilTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void ignoresDirectoriesAndResourcesInsideTheGeneratedRoutePackage() {
+        File input = temporaryFolder.newFile('routes.jar')
+        JarOutputStream output = new JarOutputStream(new FileOutputStream(input))
+        try {
+            output.putNextEntry(new JarEntry('com/alibaba/android/arouter/routes/'))
+            output.closeEntry()
+
+            output.putNextEntry(new JarEntry('com/alibaba/android/arouter/routes/README.txt'))
+            output.write('not bytecode'.getBytes('UTF-8'))
+            output.closeEntry()
+        } finally {
+            output.close()
+        }
+
+        ScanUtil.scanJar(input, temporaryFolder.newFile('destination.jar'))
+    }
+
+    @Test
+    void onlyProcessesClassFilesInsideTheGeneratedRoutePackage() {
+        assertTrue(ScanUtil.shouldProcessClass('com/alibaba/android/arouter/routes/ARouter$$Root$$app.class'))
+        assertFalse(ScanUtil.shouldProcessClass('com/alibaba/android/arouter/routes/'))
+        assertFalse(ScanUtil.shouldProcessClass('com/alibaba/android/arouter/routes/metadata.json'))
+        assertFalse(ScanUtil.shouldProcessClass('other/package/Route.class'))
+    }
+}

--- a/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
+++ b/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/KotlinTestActivity.kt
@@ -14,6 +14,10 @@ class KotlinTestActivity : Activity() {
     @JvmField var name: String? = null
     @Autowired
     @JvmField var age: Int? = 0
+    @Autowired
+    @JvmField var nullableAge: Int? = null
+    @Autowired
+    @JvmField var nullableEnabled: Boolean? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         ARouter.getInstance().inject(this)  // Start auto inject.


### PR DESCRIPTION
## Summary

- Use the effective navigation context for `PretreatmentService` when callers omit a Context.
- Resolve legacy Fragment types defensively and recognize AndroidX Fragment routes.
- Generate null-safe Bundle-based autowiring that preserves defaults and Kotlin nullable primitive wrappers.
- Skip directories and non-class resources while scanning generated route entries in jars.
- Add compiler, API, Gradle plugin, and real KAPT regression coverage.

Refs #1055, #1074, #898, #814, and #1026.

## Compatibility

- Keeps the existing public API and binary surface unchanged.
- Retains the support-v4 baseline while allowing optional AndroidX Fragment types during annotation processing.
- Keeps the existing AGP 4.1.1 / Gradle 6.5 / JDK 8 build baseline.

## Verification

- [x] `./gradlew --no-daemon --stacktrace --rerun-tasks :arouter-compiler:test :arouter-gradle-plugin:test :arouter-api:testDebugUnitTest :module-kotlin:compileDebugKotlin`
- [x] `./gradlew --no-daemon --stacktrace :arouter-gradle-plugin:build`
- [x] `./gradlew --no-daemon --stacktrace -Parouter.useLocalRegisterPlugin :arouter-annotation:build :arouter-compiler:build :arouter-api:testDebugUnitTest :arouter-api:assemble assembleDebug`
- [x] KAPT route documentation and local Maven artifact generation verified.
- [x] No generated files, build output, credentials, or unrelated formatting are included.
- [x] Targets `develop`.