### PR TITLE
Migrate ARouter to native AndroidX and add device regression gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,130 @@ jobs:
         if: matrix.agp == '7.4.2'
         run: ./gradle/verify-kapt-room.sh
 
+  device-tests:
+    name: Device tests (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: API 21 / Debug
+            api: 21
+            build_type: debug
+            consumer: false
+          - label: API 21 / Release R8
+            api: 21
+            build_type: release
+            consumer: false
+          - label: API 34 / Debug
+            api: 34
+            build_type: debug
+            consumer: false
+          - label: API 34 / Release R8
+            api: 34
+            build_type: release
+            consumer: false
+          - label: API 34 / AndroidX consumer / Debug and R8
+            api: 34
+            build_type: consumer
+            consumer: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 8 for local ARouter artifacts
+        id: java8
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: gradle
+
+      - name: Set up JDK 17 for SDK tools and the consumer fixture
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      - name: Install build SDK packages
+        run: sdkmanager "platforms;android-29" "build-tools;29.0.2" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Stage current ARouter artifacts for the consumer fixture
+        if: matrix.consumer
+        env:
+          JAVA_HOME: ${{ steps.java8.outputs.path }}
+        run: >-
+          ./gradlew --no-daemon --stacktrace
+          :arouter-annotation:installLocally
+          :arouter-compiler:installLocally
+          :arouter-api:installLocally
+          :arouter-gradle-plugin:installLocally
+
+      - name: Enable emulator acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run complete device tests
+        if: ${{ !matrix.consumer }}
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
+        env:
+          AROUTER_JAVA8_HOME: ${{ steps.java8.outputs.path }}
+          AROUTER_EXPECT_API: ${{ matrix.api }}
+          AROUTER_TEST_BUILD_TYPE: ${{ matrix.build_type }}
+        with:
+          api-level: ${{ matrix.api }}
+          arch: x86_64
+          target: default
+          disable-animations: true
+          script: env JAVA_HOME="$AROUTER_JAVA8_HOME" ./gradle/verify-device-tests.sh "$AROUTER_TEST_BUILD_TYPE"
+
+      - name: Verify upgraded AndroidX consumer without Jetifier
+        if: matrix.consumer
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
+        env:
+          AROUTER_AGP_VERSION: 9.3.2
+          AROUTER_GRADLE_WRAPPER_PROPERTIES: gradle-wrapper-9.5.properties
+          AROUTER_COMPILE_SDK: '36'
+          AROUTER_BUILD_TOOLS: 36.0.0
+          AROUTER_MIN_SDK: '23'
+          AROUTER_ANDROIDX_CORE_VERSION: 1.17.0
+          AROUTER_ANDROIDX_FRAGMENT_VERSION: 1.8.9
+          AROUTER_RUN_DEVICE_TESTS: 'true'
+          AROUTER_KEEP_TEST_ROOT: 'true'
+          TMPDIR: ${{ runner.temp }}
+        with:
+          api-level: 34
+          arch: x86_64
+          target: default
+          disable-animations: true
+          script: ./gradle/verify-configuration-cache.sh
+
+      - name: Preserve device reports and R8 mappings
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: device-tests-api-${{ matrix.api }}-${{ matrix.build_type }}
+          retention-days: 14
+          path: |
+            app/build/reports/androidTests/
+            app/build/outputs/androidTest-results/
+            app/build/outputs/mapping/release/
+            arouter-api/build/reports/androidTests/
+            arouter-api/build/outputs/androidTest-results/
+            ${{ runner.temp }}/arouter-gradle-plugin.*/device-*.log
+            ${{ runner.temp }}/arouter-gradle-plugin.*/project/app/build/reports/androidTests/
+            ${{ runner.temp }}/arouter-gradle-plugin.*/project/app/build/outputs/androidTest-results/
+            ${{ runner.temp }}/arouter-gradle-plugin.*/project/app/build/outputs/mapping/
+
   idea-plugin:
     name: IDE navigation plugin (IntelliJ / Android Studio)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,12 @@ jobs:
           :arouter-api:installLocally
           :arouter-gradle-plugin:installLocally
 
+      - name: Install AndroidX verification tools
+        if: matrix.agp == '7.4.2'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ripgrep unzip binutils
+
       - name: Verify native AndroidX dependency contract
         if: matrix.agp == '7.4.2'
         run: ./gradle/verify-androidx.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,10 +189,20 @@ jobs:
             api: 34
             build_type: release
             consumer: false
-          - label: API 34 / AndroidX consumer / Debug and R8
+          - label: API 21 / minimum AndroidX consumer / Debug and R8
+            api: 21
+            build_type: consumer
+            consumer: true
+            min_sdk: '14'
+            core_version: '1.0.2'
+            fragment_version: '1.0.0'
+          - label: API 34 / upgraded AndroidX consumer / Debug and R8
             api: 34
             build_type: consumer
             consumer: true
+            min_sdk: '23'
+            core_version: '1.17.0'
+            fragment_version: '1.8.9'
 
     steps:
       - name: Checkout
@@ -251,7 +261,7 @@ jobs:
           disable-animations: true
           script: env JAVA_HOME="$AROUTER_JAVA8_HOME" ./gradle/verify-device-tests.sh "$AROUTER_TEST_BUILD_TYPE"
 
-      - name: Verify upgraded AndroidX consumer without Jetifier
+      - name: Verify AndroidX consumer without Jetifier
         if: matrix.consumer
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         env:
@@ -259,14 +269,14 @@ jobs:
           AROUTER_GRADLE_WRAPPER_PROPERTIES: gradle-wrapper-9.5.properties
           AROUTER_COMPILE_SDK: '36'
           AROUTER_BUILD_TOOLS: 36.0.0
-          AROUTER_MIN_SDK: '23'
-          AROUTER_ANDROIDX_CORE_VERSION: 1.17.0
-          AROUTER_ANDROIDX_FRAGMENT_VERSION: 1.8.9
+          AROUTER_MIN_SDK: ${{ matrix.min_sdk }}
+          AROUTER_ANDROIDX_CORE_VERSION: ${{ matrix.core_version }}
+          AROUTER_ANDROIDX_FRAGMENT_VERSION: ${{ matrix.fragment_version }}
           AROUTER_RUN_DEVICE_TESTS: 'true'
           AROUTER_KEEP_TEST_ROOT: 'true'
           TMPDIR: ${{ runner.temp }}
         with:
-          api-level: 34
+          api-level: ${{ matrix.api }}
           arch: x86_64
           target: default
           disable-animations: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,10 @@ jobs:
           :arouter-api:installLocally
           :arouter-gradle-plugin:installLocally
 
+      - name: Verify native AndroidX dependency contract
+        if: matrix.agp == '7.4.2'
+        run: ./gradle/verify-androidx.sh
+
       - name: Set up matrix JDK
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ version|[![Download](https://maven-badges.herokuapp.com/maven-central/com.alibab
 4. Cross-module communication, decouple components by IoC
 
 #### III. Configuration
+The current development line uses AndroidX natively. Applications consuming it must enable
+`android.useAndroidX=true`; ARouter itself does not require Jetifier. Projects that still use
+the legacy Support Library should remain on an ARouter 1.x release until the application has
+migrated to AndroidX. The namespace change is a source and binary compatibility boundary, so
+its release will be handled as a major-version change.
+
 1. Adding dependencies and configurations
     ``` gradle
     android {
@@ -55,6 +61,9 @@ version|[![Download](https://maven-badges.herokuapp.com/maven-central/com.alibab
             }
         }
     }
+
+    // Required by the current AndroidX development line.
+    // gradle.properties: android.useAndroidX=true
 
     dependencies {
         // Replace with the latest version

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,6 +44,11 @@
 4. 跨模块API调用，通过控制反转来做组件解耦
 
 #### 三、基础功能
+当前开发线已原生迁移到 AndroidX。接入方必须启用 `android.useAndroidX=true`，ARouter
+自身不需要 Jetifier。仍使用旧 Support Library 的项目应继续使用 ARouter 1.x，待应用完成
+AndroidX 迁移后再升级。命名空间变化构成源码和二进制兼容边界，因此正式发布时会按大版本
+变更处理。
+
 1. 添加依赖和配置
     ``` gradle
     android {
@@ -56,6 +61,9 @@
             }
         }
     }
+
+    // 当前 AndroidX 开发线必须启用。
+    // gradle.properties: android.useAndroidX=true
 
     dependencies {
         // 替换成最新版本, 需要注意的是api

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion Integer.parseInt(MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(TARGET_SDK_VERSION)
         versionName "0.0.1"
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     compileOptions {
@@ -59,7 +59,8 @@ dependencies {
 
     implementation project(':module-kotlin')
 
-    implementation "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
-    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    implementation "androidx.core:core:${ANDROIDX_CORE_VERSION}"
+    implementation "androidx.appcompat:appcompat:${ANDROIDX_APPCOMPAT_VERSION}"
+    androidTestImplementation "androidx.test:runner:${ANDROIDX_TEST_RUNNER_VERSION}"
+    androidTestImplementation "androidx.test.ext:junit:${ANDROIDX_TEST_EXT_JUNIT_VERSION}"
 }

--- a/app/proguard-android-test.pro
+++ b/app/proguard-android-test.pro
@@ -32,3 +32,9 @@
 -keep interface com.alibaba.android.arouter.facade.callback.NavigationLauncher {
     *;
 }
+
+# The target APK is minified separately from the instrumentation APK. Preserve
+# the AndroidX factory invoked directly by the cross-APK public API test.
+-keep class androidx.core.app.ActivityOptionsCompat {
+    public static androidx.core.app.ActivityOptionsCompat makeCustomAnimation(android.content.Context, int, int);
+}

--- a/app/src/androidTest/java/com/alibaba/android/arouter/core/InstrumentationHookIntentRobustnessInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/core/InstrumentationHookIntentRobustnessInstrumentedTest.java
@@ -6,8 +6,9 @@ import android.content.Intent;
 import android.os.BadParcelableException;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.facade.template.ILogger;
 import com.alibaba.android.arouter.launcher.ARouter;

--- a/app/src/androidTest/java/com/alibaba/android/arouter/core/RouteAvailabilityInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/core/RouteAvailabilityInstrumentedTest.java
@@ -1,8 +1,9 @@
 package com.alibaba.android.arouter.core;
 
 import android.app.Application;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.Test1Activity;
 import com.alibaba.android.arouter.demo.module1.testservice.HelloServiceImpl;
@@ -34,7 +35,7 @@ public class RouteAvailabilityInstrumentedTest {
             // The first test in a fresh process has no initialized router to destroy.
         }
 
-        Application application = (Application) InstrumentationRegistry
+        Application application = (Application) InstrumentationRegistry.getInstrumentation()
                 .getTargetContext()
                 .getApplicationContext();
         ARouter.init(application);

--- a/app/src/androidTest/java/com/alibaba/android/arouter/core/RoutingFailureDiagnosticsInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/core/RoutingFailureDiagnosticsInstrumentedTest.java
@@ -1,8 +1,9 @@
 package com.alibaba.android.arouter.core;
 
 import android.app.Application;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.testservice.FailingProvider;
 import com.alibaba.android.arouter.exception.HandlerException;
@@ -30,7 +31,7 @@ public class RoutingFailureDiagnosticsInstrumentedTest {
             // The first test in a fresh process has no initialized router to destroy.
         }
 
-        Application application = (Application) InstrumentationRegistry
+        Application application = (Application) InstrumentationRegistry.getInstrumentation()
                 .getTargetContext()
                 .getApplicationContext();
         ARouter.init(application);

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/ARouterEndToEndTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/ARouterEndToEndTest.java
@@ -4,10 +4,14 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
 import android.widget.TextView;
+
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.fragment.app.Fragment;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.kotlin.KotlinTestActivity;
 import com.alibaba.android.arouter.demo.kotlin.RecordingPretreatmentService;
@@ -40,7 +44,7 @@ public class ARouterEndToEndTest {
 
     @BeforeClass
     public static void initializeRouter() {
-        Application application = (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        Application application = (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.openLog();
         ARouter.init(application);
@@ -60,6 +64,7 @@ public class ARouterEndToEndTest {
                 .navigation();
 
         assertNotNull(service);
+        assertTrue(fragment instanceof Fragment);
         assertTrue(fragment instanceof BlankFragment);
         Bundle arguments = ((BlankFragment) fragment).getArguments();
         assertNotNull(arguments);
@@ -67,9 +72,27 @@ public class ARouterEndToEndTest {
     }
 
     @Test
+    public void androidXActivityOptionsRemainPartOfPostcardContract() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            return;
+        }
+
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
+                context,
+                android.R.anim.fade_in,
+                android.R.anim.fade_out
+        );
+        Postcard postcard = ARouter.getInstance().build("/test/activity2");
+
+        assertSame(postcard, postcard.withOptionsCompat(options));
+        assertNotNull(postcard.getOptionsBundle());
+    }
+
+    @Test
     public void kotlinPretreatmentUsesApplicationContextForContextlessNavigation() {
         RecordingPretreatmentService.startRecording();
-        Context applicationContext = InstrumentationRegistry.getTargetContext().getApplicationContext();
+        Context applicationContext = InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
 
         Object fragment = ARouter.getInstance()
                 .build("/test/fragment")
@@ -85,7 +108,7 @@ public class ARouterEndToEndTest {
     @Test
     public void kotlinPretreatmentPreservesExplicitNavigationContext() {
         RecordingPretreatmentService.startRecording();
-        Context explicitContext = InstrumentationRegistry.getTargetContext();
+        Context explicitContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         Object fragment = ARouter.getInstance()
                 .build("/test/fragment")
@@ -112,7 +135,7 @@ public class ARouterEndToEndTest {
                     .withBoolean("boy", true)
                     .withLong("high", 181)
                     .withString("url", "https://example.test")
-                    .navigation(InstrumentationRegistry.getTargetContext(), callback);
+                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), callback);
 
             Activity activity = monitor.waitForActivityWithTimeout(5000);
             assertNotNull(activity);
@@ -172,7 +195,7 @@ public class ARouterEndToEndTest {
             ARouter.getInstance()
                     .build("/test/activity2")
                     .withString("key1", "interceptor-chain-passed")
-                    .navigation(InstrumentationRegistry.getTargetContext(), callback);
+                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), callback);
 
             Activity activity = monitor.waitForActivityWithTimeout(5000);
             assertNotNull(activity);
@@ -199,7 +222,7 @@ public class ARouterEndToEndTest {
 
         ARouter.getInstance()
                 .build("/missing/route")
-                .navigation(InstrumentationRegistry.getTargetContext(), callback);
+                .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), callback);
 
         assertTrue(callback.await());
         assertTrue(callback.lost.get());

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/ActivityResultNavigationTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/ActivityResultNavigationTest.java
@@ -6,8 +6,9 @@ import android.app.Instrumentation;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Looper;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.BlankFragment;
 import com.alibaba.android.arouter.demo.module1.testactivity.Test2Activity;
@@ -43,7 +44,7 @@ public class ActivityResultNavigationTest {
 
     @BeforeClass
     public static void initializeRouter() {
-        Application application = (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        Application application = (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.openLog();
         ARouter.init(application);
@@ -82,7 +83,7 @@ public class ActivityResultNavigationTest {
                     .withString("key1", "launcher-value")
                     .withAction("com.alibaba.android.arouter.TEST_RESULT")
                     .withFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    .navigation(InstrumentationRegistry.getTargetContext(), new NavigationLauncher() {
+                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), new NavigationLauncher() {
                         @Override
                         public void launch(Intent intent) {
                             events.add("launch");
@@ -282,7 +283,7 @@ public class ActivityResultNavigationTest {
             ARouter.getInstance()
                     .build("/test/activity2")
                     .withString("key1", "legacy-value")
-                    .navigation(InstrumentationRegistry.getTargetContext(), new RecordingCallback(events, completed));
+                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), new RecordingCallback(events, completed));
 
             Activity target = monitor.waitForActivityWithTimeout(5000);
             assertNotNull(target);
@@ -311,10 +312,10 @@ public class ActivityResultNavigationTest {
         Object fragment = ARouter.getInstance()
                 .build("/test/fragment")
                 .withString("name", "fragment-value")
-                .navigation(InstrumentationRegistry.getTargetContext(), launcher, null);
+                .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), launcher, null);
         Object provider = ARouter.getInstance()
                 .build("/yourservicegroupname/hello")
-                .navigation(InstrumentationRegistry.getTargetContext(), launcher, null);
+                .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), launcher, null);
 
         assertTrue(fragment instanceof BlankFragment);
         Bundle arguments = ((BlankFragment) fragment).getArguments();
@@ -332,7 +333,7 @@ public class ActivityResultNavigationTest {
 
         ARouter.getInstance()
                 .build("/missing/activity-result-route")
-                .navigation(InstrumentationRegistry.getTargetContext(), new NavigationLauncher() {
+                .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), new NavigationLauncher() {
                     @Override
                     public void launch(Intent intent) {
                         launches.incrementAndGet();
@@ -345,7 +346,7 @@ public class ActivityResultNavigationTest {
     }
 
     private static ActivityResultHostActivity launchHostActivity(Instrumentation instrumentation) {
-        Intent intent = new Intent(InstrumentationRegistry.getTargetContext(), ActivityResultHostActivity.class);
+        Intent intent = new Intent(InstrumentationRegistry.getInstrumentation().getTargetContext(), ActivityResultHostActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         return (ActivityResultHostActivity) instrumentation.startActivitySync(intent);
     }

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/ActivityTaskFlagsInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/ActivityTaskFlagsInstrumentedTest.java
@@ -6,8 +6,9 @@ import android.app.Instrumentation;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.ReorderProbeActivity;
 import com.alibaba.android.arouter.launcher.ARouter;
@@ -34,7 +35,7 @@ public class ActivityTaskFlagsInstrumentedTest {
     @Before
     public void setUp() {
         instrumentation = InstrumentationRegistry.getInstrumentation();
-        application = (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        application = (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.init(application);
     }

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/AutowiredR8InjectionTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/AutowiredR8InjectionTest.java
@@ -4,9 +4,10 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
 import android.widget.TextView;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.launcher.ARouter;
 
@@ -25,7 +26,7 @@ public class AutowiredR8InjectionTest {
 
     @BeforeClass
     public static void initializeRouter() {
-        Application application = (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        Application application = (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.openLog();
         ARouter.init(application);
@@ -51,7 +52,7 @@ public class AutowiredR8InjectionTest {
     @Test
     public void fragmentFieldsAreInjectedAfterMinification() {
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
-        Intent intent = new Intent(InstrumentationRegistry.getTargetContext(), AutowiredFragmentHostActivity.class);
+        Intent intent = new Intent(InstrumentationRegistry.getInstrumentation().getTargetContext(), AutowiredFragmentHostActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         activity = instrumentation.startActivitySync(intent);
 

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
@@ -6,6 +6,10 @@ import android.app.Instrumentation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.lifecycle.ActivityLifecycleCallback;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitor;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.RedirectLoginActivity;
 import com.alibaba.android.arouter.demo.module1.testactivity.RedirectProtectedActivity;
@@ -27,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -47,8 +52,12 @@ public class InterceptorRedirectInstrumentedTest {
     }
 
     @After
-    public void tearDown() {
-        finishCurrentActivity();
+    public void tearDown() throws InterruptedException {
+        try {
+            finishCurrentActivity();
+        } finally {
+            LoginRedirectInterceptor.resetProbe();
+        }
     }
 
     @Test
@@ -81,24 +90,34 @@ public class InterceptorRedirectInstrumentedTest {
 
     @Test
     public void repeatedRedirectsDoNotBlockLaterNavigation() throws Exception {
-        Instrumentation.ActivityMonitor loginMonitor =
-                instrumentation.addMonitor(RedirectLoginActivity.class.getName(), null, false);
         Instrumentation.ActivityMonitor protectedMonitor =
                 instrumentation.addMonitor(RedirectProtectedActivity.class.getName(), null, false);
         Instrumentation.ActivityMonitor normalMonitor =
                 instrumentation.addMonitor(Test2Activity.class.getName(), null, false);
 
         try {
+            Activity previousLogin = null;
             for (int index = 0; index < REDIRECT_COUNT; index++) {
-                RecordingNavigationCallback redirect = new RecordingNavigationCallback();
-                navigateProtected(redirect);
-                currentActivity = loginMonitor.waitForActivityWithTimeout(5000);
+                // ActivityMonitor can record the same instance during both
+                // creation and resume. Reusing it can mistake the previous
+                // login's resume for the next redirect's arrival.
+                Instrumentation.ActivityMonitor loginMonitor =
+                        instrumentation.addMonitor(RedirectLoginActivity.class.getName(), null, false);
+                try {
+                    RecordingNavigationCallback redirect = new RecordingNavigationCallback();
+                    navigateProtected(redirect);
+                    currentActivity = instrumentation.waitForMonitorWithTimeout(loginMonitor, 5000);
 
-                assertNotNull(currentActivity);
-                assertTrue(redirect.await());
-                assertTrue(redirect.interrupted.get());
-                assertFalse(redirect.arrived.get());
-                assertEquals(index + 1, LoginRedirectInterceptor.protectedProcessCount());
+                    assertNotNull("Login redirect " + index + " did not arrive", currentActivity);
+                    assertNotSame("A redirect reused the previous monitor result", previousLogin, currentActivity);
+                    previousLogin = currentActivity;
+                    assertTrue(redirect.await());
+                    assertTrue(redirect.interrupted.get());
+                    assertFalse(redirect.arrived.get());
+                    assertEquals(index + 1, LoginRedirectInterceptor.protectedProcessCount());
+                } finally {
+                    instrumentation.removeMonitor(loginMonitor);
+                }
                 finishCurrentActivity();
             }
 
@@ -121,7 +140,6 @@ public class InterceptorRedirectInstrumentedTest {
             assertFalse(normal.interrupted.get());
             assertEquals(1, LoginRedirectInterceptor.watchedPostcardProcessCount());
         } finally {
-            instrumentation.removeMonitor(loginMonitor);
             instrumentation.removeMonitor(protectedMonitor);
             instrumentation.removeMonitor(normalMonitor);
         }
@@ -133,20 +151,47 @@ public class InterceptorRedirectInstrumentedTest {
                 .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), callback);
     }
 
-    private void finishCurrentActivity() {
+    private void finishCurrentActivity() throws InterruptedException {
         final Activity activity = currentActivity;
         currentActivity = null;
-        if (activity == null || activity.isFinishing()) {
+        if (activity == null) {
             return;
         }
 
+        final CountDownLatch destroyed = new CountDownLatch(1);
+        final ActivityLifecycleMonitor lifecycle = ActivityLifecycleMonitorRegistry.getInstance();
+        final ActivityLifecycleCallback callback = new ActivityLifecycleCallback() {
+            @Override
+            public void onActivityLifecycleChanged(Activity changed, Stage stage) {
+                if (changed == activity && stage == Stage.DESTROYED) {
+                    destroyed.countDown();
+                }
+            }
+        };
         instrumentation.runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                activity.finish();
+                lifecycle.addLifecycleCallback(callback);
+                if (lifecycle.getLifecycleStageOf(activity) == Stage.DESTROYED) {
+                    destroyed.countDown();
+                } else {
+                    activity.finish();
+                }
             }
         });
-        instrumentation.waitForIdleSync();
+        try {
+            // An idle main queue does not mean the platform has completed the
+            // close transaction. Wait before installing the next login monitor.
+            assertTrue("The previous activity was not destroyed", destroyed.await(5, TimeUnit.SECONDS));
+            instrumentation.waitForIdleSync();
+        } finally {
+            instrumentation.runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    lifecycle.removeLifecycleCallback(callback);
+                }
+            });
+        }
     }
 
     private static final class RecordingNavigationCallback implements NavigationCallback {

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
@@ -68,7 +68,7 @@ public class InterceptorRedirectInstrumentedTest {
             instrumentation.waitForIdleSync();
             assertEquals(1, loginMonitor.getHits());
             assertEquals(0, protectedMonitor.getHits());
-            assertEquals(1, LoginRedirectInterceptor.processCount());
+            assertEquals(1, LoginRedirectInterceptor.protectedProcessCount());
             assertTrue(callback.found.get());
             assertTrue(callback.interrupted.get());
             assertFalse(callback.lost.get());
@@ -98,17 +98,20 @@ public class InterceptorRedirectInstrumentedTest {
                 assertTrue(redirect.await());
                 assertTrue(redirect.interrupted.get());
                 assertFalse(redirect.arrived.get());
-                assertEquals(index + 1, LoginRedirectInterceptor.processCount());
+                assertEquals(index + 1, LoginRedirectInterceptor.protectedProcessCount());
                 finishCurrentActivity();
             }
 
             assertEquals(0, protectedMonitor.getHits());
-            assertEquals(REDIRECT_COUNT, LoginRedirectInterceptor.processCount());
+            assertEquals(REDIRECT_COUNT, LoginRedirectInterceptor.protectedProcessCount());
 
             RecordingNavigationCallback normal = new RecordingNavigationCallback();
-            ARouter.getInstance()
-                    .build("/test/activity2")
-                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), normal);
+            Postcard normalPostcard = ARouter.getInstance().build("/test/activity2");
+            LoginRedirectInterceptor.watchPostcard(normalPostcard);
+            normalPostcard.navigation(
+                    InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                    normal
+            );
             currentActivity = normalMonitor.waitForActivityWithTimeout(5000);
 
             assertNotNull(currentActivity);
@@ -116,7 +119,7 @@ public class InterceptorRedirectInstrumentedTest {
             assertTrue(normal.found.get());
             assertTrue(normal.arrived.get());
             assertFalse(normal.interrupted.get());
-            assertEquals(REDIRECT_COUNT + 1, LoginRedirectInterceptor.processCount());
+            assertEquals(1, LoginRedirectInterceptor.watchedPostcardProcessCount());
         } finally {
             instrumentation.removeMonitor(loginMonitor);
             instrumentation.removeMonitor(protectedMonitor);

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/InterceptorRedirectInstrumentedTest.java
@@ -3,8 +3,9 @@ package com.alibaba.android.arouter.demo;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.RedirectLoginActivity;
 import com.alibaba.android.arouter.demo.module1.testactivity.RedirectProtectedActivity;
@@ -39,7 +40,7 @@ public class InterceptorRedirectInstrumentedTest {
     public void setUp() {
         instrumentation = InstrumentationRegistry.getInstrumentation();
         Application application =
-                (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+                (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.init(application);
         LoginRedirectInterceptor.resetProbe();
@@ -107,7 +108,7 @@ public class InterceptorRedirectInstrumentedTest {
             RecordingNavigationCallback normal = new RecordingNavigationCallback();
             ARouter.getInstance()
                     .build("/test/activity2")
-                    .navigation(InstrumentationRegistry.getTargetContext(), normal);
+                    .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), normal);
             currentActivity = normalMonitor.waitForActivityWithTimeout(5000);
 
             assertNotNull(currentActivity);
@@ -126,7 +127,7 @@ public class InterceptorRedirectInstrumentedTest {
     private void navigateProtected(RecordingNavigationCallback callback) {
         ARouter.getInstance()
                 .build("/redirect/protected")
-                .navigation(InstrumentationRegistry.getTargetContext(), callback);
+                .navigation(InstrumentationRegistry.getInstrumentation().getTargetContext(), callback);
     }
 
     private void finishCurrentActivity() {

--- a/app/src/androidTest/java/com/alibaba/android/arouter/demo/PostcardArrayExtrasTest.java
+++ b/app/src/androidTest/java/com/alibaba/android/arouter/demo/PostcardArrayExtrasTest.java
@@ -4,8 +4,9 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.Test2Activity;
 import com.alibaba.android.arouter.launcher.ARouter;
@@ -29,7 +30,7 @@ public class PostcardArrayExtrasTest {
 
     @BeforeClass
     public static void initializeRouter() {
-        Application application = (Application) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        Application application = (Application) InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         ARouter.openDebug();
         ARouter.openLog();
         ARouter.init(application);
@@ -56,7 +57,7 @@ public class PostcardArrayExtrasTest {
         Instrumentation.ActivityMonitor monitor = instrumentation.addMonitor(Test2Activity.class.getName(), null, false);
 
         try {
-            Intent hostIntent = new Intent(InstrumentationRegistry.getTargetContext(), PostcardArrayHostActivity.class);
+            Intent hostIntent = new Intent(InstrumentationRegistry.getInstrumentation().getTargetContext(), PostcardArrayHostActivity.class);
             hostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             activities.add(instrumentation.startActivitySync(hostIntent));
 

--- a/app/src/main/java/com/alibaba/android/arouter/demo/ActivityResultHostActivity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/ActivityResultHostActivity.java
@@ -2,7 +2,8 @@ package com.alibaba.android.arouter.demo;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.support.v4.app.ActivityCompat;
+
+import androidx.core.app.ActivityCompat;
 
 import com.alibaba.android.arouter.facade.Postcard;
 import com.alibaba.android.arouter.facade.callback.NavigationCallback;

--- a/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
+++ b/app/src/main/java/com/alibaba/android/arouter/demo/MainActivity.java
@@ -4,12 +4,13 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.app.ActivityOptionsCompat;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.fragment.app.Fragment;
 
 import com.alibaba.android.arouter.demo.module1.testactivity.TestDynamicActivity;
 import com.alibaba.android.arouter.demo.service.model.TestObj;

--- a/arouter-api/build.gradle
+++ b/arouter-api/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion Integer.parseInt(MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(TARGET_SDK_VERSION)
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
 
         javaCompileOptions {
@@ -35,11 +35,13 @@ android {
 dependencies {
     annotationProcessor project(':arouter-compiler')
     api project(':arouter-annotation')
-    implementation "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
+    api "androidx.core:core:${ANDROIDX_CORE_VERSION}"
+    implementation "androidx.fragment:fragment:${ANDROIDX_FRAGMENT_VERSION}"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation "androidx.test:runner:${ANDROIDX_TEST_RUNNER_VERSION}"
+    androidTestImplementation "androidx.test.ext:junit:${ANDROIDX_TEST_EXT_JUNIT_VERSION}"
 }
 
 apply from: rootProject.file('gradle/publish.gradle')

--- a/arouter-api/consumer-rules.pro
+++ b/arouter-api/consumer-rules.pro
@@ -25,5 +25,14 @@
     public <init>();
 }
 
+# Fragment routes use the same reflective public no-argument constructor contract.
+# Older AndroidX releases do not supply their own Fragment constructor rules.
+-keepclassmembers,allowoptimization,allowobfuscation class * extends androidx.fragment.app.Fragment {
+    public <init>();
+}
+-keepclassmembers,allowoptimization,allowobfuscation class * extends android.app.Fragment {
+    public <init>();
+}
+
 # by-type provider lookup uses the interface's canonical name as the generated map key.
 -keep,allowoptimization interface * implements com.alibaba.android.arouter.facade.template.IProvider

--- a/arouter-api/src/androidTest/java/com/alibaba/android/arouter/core/InterceptorChainInstrumentedTest.java
+++ b/arouter-api/src/androidTest/java/com/alibaba/android/arouter/core/InterceptorChainInstrumentedTest.java
@@ -1,8 +1,9 @@
 package com.alibaba.android.arouter.core;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.exception.HandlerException;
 import com.alibaba.android.arouter.facade.Postcard;
@@ -317,7 +318,7 @@ public class InterceptorChainInstrumentedTest {
         Warehouse.interceptorsIndex.put(1, MissingCallbackInterceptor.class);
 
         InterceptorServiceImpl service = new InterceptorServiceImpl();
-        service.init(InstrumentationRegistry.getTargetContext());
+        service.init(InstrumentationRegistry.getInstrumentation().getTargetContext());
         final CountDownLatch completed = new CountDownLatch(navigationCount);
         final AtomicInteger continued = new AtomicInteger();
         final AtomicInteger interrupted = new AtomicInteger();

--- a/arouter-api/src/androidTest/java/com/alibaba/android/arouter/core/InterceptorServiceImplInstrumentedTest.java
+++ b/arouter-api/src/androidTest/java/com/alibaba/android/arouter/core/InterceptorServiceImplInstrumentedTest.java
@@ -1,8 +1,9 @@
 package com.alibaba.android.arouter.core;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.alibaba.android.arouter.exception.HandlerException;
 import com.alibaba.android.arouter.facade.Postcard;
@@ -205,7 +206,7 @@ public class InterceptorServiceImplInstrumentedTest {
     }
 
     private static Context targetContext() {
-        return InstrumentationRegistry.getTargetContext();
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
     }
 
     private static long elapsedMillis(long startedAt) {

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/facade/Postcard.java
@@ -6,10 +6,11 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.ActivityOptionsCompat;
 import android.util.SparseArray;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityOptionsCompat;
 
 import com.alibaba.android.arouter.facade.callback.NavigationCallback;
 import com.alibaba.android.arouter.facade.callback.NavigationLauncher;

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
@@ -8,9 +8,10 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.core.app.ActivityCompat;
 
 import com.alibaba.android.arouter.core.InstrumentationHook;
 import com.alibaba.android.arouter.core.LogisticsCenter;
@@ -462,8 +463,8 @@ final class _ARouter {
                     Object instance = fragmentMeta.getConstructor().newInstance();
                     if (instance instanceof Fragment) {
                         ((Fragment) instance).setArguments(postcard.getExtras());
-                    } else if (instance instanceof android.support.v4.app.Fragment) {
-                        ((android.support.v4.app.Fragment) instance).setArguments(postcard.getExtras());
+                    } else if (instance instanceof androidx.fragment.app.Fragment) {
+                        ((androidx.fragment.app.Fragment) instance).setArguments(postcard.getExtras());
                     }
 
                     return instance;

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/launcher/_ARouter.java
@@ -469,7 +469,8 @@ final class _ARouter {
 
                     return instance;
                 } catch (Exception ex) {
-                    logger.error(Consts.TAG, "Fetch fragment instance error, " + TextUtils.formatStackTrace(ex.getStackTrace()));
+                    logger.error(Consts.TAG, "Fetch fragment instance error, "
+                            + (fragmentMeta == null ? "null" : fragmentMeta.getName()), ex);
                 }
             case METHOD:
             case SERVICE:

--- a/arouter-api/src/main/java/com/alibaba/android/arouter/thread/DefaultThreadFactory.java
+++ b/arouter-api/src/main/java/com/alibaba/android/arouter/thread/DefaultThreadFactory.java
@@ -1,6 +1,6 @@
 package com.alibaba.android.arouter.thread;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.alibaba.android.arouter.launcher.ARouter;
 import com.alibaba.android.arouter.utils.Consts;

--- a/arouter-api/src/test/java/com/alibaba/android/arouter/launcher/FragmentInstantiationDiagnosticsTest.java
+++ b/arouter-api/src/test/java/com/alibaba/android/arouter/launcher/FragmentInstantiationDiagnosticsTest.java
@@ -1,0 +1,91 @@
+package com.alibaba.android.arouter.launcher;
+
+import com.alibaba.android.arouter.facade.Postcard;
+import com.alibaba.android.arouter.facade.callback.NavigationCallback;
+import com.alibaba.android.arouter.facade.callback.NavigationLauncher;
+import com.alibaba.android.arouter.facade.enums.RouteType;
+import com.alibaba.android.arouter.facade.template.ILogger;
+import com.alibaba.android.arouter.utils.Consts;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class FragmentInstantiationDiagnosticsTest {
+    private ILogger originalLogger;
+    private ILogger logger;
+    private _ARouter router;
+    private Method navigation;
+
+    @Before
+    public void setUp() throws Exception {
+        originalLogger = _ARouter.logger;
+        logger = mock(ILogger.class);
+        _ARouter.logger = logger;
+        Constructor<_ARouter> constructor = _ARouter.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        router = constructor.newInstance();
+        navigation = _ARouter.class.getDeclaredMethod("_navigation", Postcard.class,
+                int.class, NavigationLauncher.class, NavigationCallback.class);
+        navigation.setAccessible(true);
+    }
+
+    @After
+    public void tearDown() {
+        _ARouter.logger = originalLogger;
+    }
+
+    @Test
+    public void missingPublicNoArgumentConstructorLogsExceptionAndReturnsNull() throws Exception {
+        Throwable failure = navigateFailingTarget(MissingDefaultConstructor.class);
+        assertTrue(failure instanceof NoSuchMethodException);
+    }
+
+    @Test
+    public void throwingConstructorPreservesCauseAndReturnsNull() throws Exception {
+        Throwable failure = navigateFailingTarget(ThrowingConstructor.class);
+        assertTrue(failure instanceof InvocationTargetException);
+        assertTrue(failure.getCause() instanceof IllegalStateException);
+        assertEquals("fragment-constructor-detail", failure.getCause().getMessage());
+    }
+
+    @Test
+    public void nullDestinationLogsFailureAndReturnsNull() throws Exception {
+        assertTrue(navigateFailingTarget(null) instanceof NullPointerException);
+    }
+
+    private Throwable navigateFailingTarget(Class<?> destination) throws Exception {
+        Postcard postcard = new Postcard();
+        postcard.setType(RouteType.FRAGMENT);
+        postcard.setDestination(destination);
+        assertNull(navigation.invoke(router, postcard, -1, null, null));
+
+        ArgumentCaptor<Throwable> cause = ArgumentCaptor.forClass(Throwable.class);
+        String destinationName = destination == null ? "null" : destination.getName();
+        verify(logger).error(eq(Consts.TAG), contains(destinationName), cause.capture());
+        return cause.getValue();
+    }
+
+    public static final class MissingDefaultConstructor {
+        public MissingDefaultConstructor(String ignored) {}
+    }
+
+    public static final class ThrowingConstructor {
+        public ThrowingConstructor() {
+            throw new IllegalStateException("fragment-constructor-detail");
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,9 +20,19 @@ org.gradle.daemon=true
 
 COMPILE_SDK_VERSION=29
 BUILDTOOLS_VERSION=29.0.2
-SUPPORT_LIB_VERSION=28.0.0
+ANDROIDX_CORE_VERSION=1.0.2
+ANDROIDX_FRAGMENT_VERSION=1.0.0
+ANDROIDX_APPCOMPAT_VERSION=1.0.2
+ANDROIDX_CONSTRAINTLAYOUT_VERSION=1.1.3
+ANDROIDX_TEST_RUNNER_VERSION=1.3.0
+ANDROIDX_TEST_EXT_JUNIT_VERSION=1.1.2
 MIN_SDK_VERSION=14
 TARGET_SDK_VERSION=28
+
+# ARouter is compiled and tested as a native AndroidX library. Jetifier stays
+# disabled so legacy support-library references cannot be hidden by rewriting.
+android.useAndroidX=true
+android.enableJetifier=false
 
 GROUP=com.alibaba
 

--- a/gradle/TESTING.md
+++ b/gradle/TESTING.md
@@ -1,0 +1,76 @@
+# AndroidX development checks
+
+These checks validate development artifacts, not a release or publication.
+ARouter's published minimum dependencies and `minSdkVersion=14` are unchanged.
+Device coverage starts at API 21; it does not establish runtime coverage for
+every API level between 14 and 20.
+
+## Complete framework device suite
+
+Use JDK 8 and connect exactly one booted Android emulator. The script rejects
+physical devices, extra devices, and a mismatched `ANDROID_SERIAL`.
+
+```sh
+export ANDROID_HOME=/path/to/android-sdk
+export JAVA_HOME=/path/to/jdk8
+AROUTER_EXPECT_API=21 ./gradle/verify-device-tests.sh debug
+AROUTER_EXPECT_API=21 ./gradle/verify-device-tests.sh release
+```
+
+Repeat on API 34. Additional arguments are passed to Gradle, for example
+`--init-script /path/to/local-repository-settings.gradle` for a local mirror.
+CI uses the configured upstream repositories, without a mirror override.
+
+Debug runs all API-module and demo instrumentation tests. Release runs the demo
+suite against the minified target APK. These cover Java/Kotlin routing, provider
+and Fragment routes, parameter injection, interceptors and redirection, task
+flags, result delivery, missing routes, and R8 behavior. The demo's narrow
+test-only keep rules preserve APIs called directly from the separate test APK;
+they are not part of the published consumer rules.
+
+The verifier requires fresh, nonempty JUnit reports with no failures, errors,
+or skipped tests. Local copies are retained by API and build type under
+`build/reports/device-tests/`, so later runs do not erase earlier matrix results.
+
+## Published-artifact consumer
+
+First stage all four local artifacts using JDK 8:
+
+```sh
+./gradlew :arouter-annotation:installLocally :arouter-compiler:installLocally \
+  :arouter-api:installLocally :arouter-gradle-plugin:installLocally
+./gradle/verify-androidx.sh
+```
+
+The existing Gradle plugin matrix checks the minimum AndroidX dependency set.
+An additional API 34 consumer job uses Core 1.17.0 and Fragment 1.8.9, pinned
+stable versions compatible with the fixture's SDK 36 toolchain. This is a
+consumer dependency override, not an upgrade of ARouter's published minimums.
+See the [Core](https://developer.android.com/jetpack/androidx/releases/core#1.17.0)
+and [Fragment](https://developer.android.com/jetpack/androidx/releases/fragment#1.8.9)
+release notes for these baselines.
+
+With JDK 17 on `PATH`, `ANDROID_SDK_ROOT` set, and an API 34 emulator booted:
+
+```sh
+AROUTER_AGP_VERSION=9.3.2 \
+AROUTER_GRADLE_WRAPPER_PROPERTIES=gradle-wrapper-9.5.properties \
+AROUTER_COMPILE_SDK=36 AROUTER_BUILD_TOOLS=36.0.0 \
+AROUTER_MIN_SDK=23 \
+AROUTER_ANDROIDX_CORE_VERSION=1.17.0 \
+AROUTER_ANDROIDX_FRAGMENT_VERSION=1.8.9 \
+AROUTER_RUN_DEVICE_TESTS=true AROUTER_KEEP_TEST_ROOT=true \
+./gradle/verify-configuration-cache.sh
+```
+
+This verifies configuration-cache reuse, incremental route updates, flavor
+isolation, and all four daily/online Debug/Release variants. Device tests launch
+the consumer through Android components and check actual routing after provider,
+Fragment argument/injection, and ActivityOptionsCompat checks. There are no
+test-only keep rules in this consumer, including its Release/R8 runs. Jetifier
+is disabled throughout.
+
+CI preserves device reports and R8 mappings even when tests fail. Set
+`AROUTER_KEEP_TEST_ROOT=true` to retain local fixture output; its exact path is
+printed by the verifier. `AROUTER_GRADLE_INIT_SCRIPT` optionally supplies a local
+repository override to the fixture.

--- a/gradle/TESTING.md
+++ b/gradle/TESTING.md
@@ -42,9 +42,11 @@ First stage all four local artifacts using JDK 8:
 ./gradle/verify-androidx.sh
 ```
 
-The existing Gradle plugin matrix checks the minimum AndroidX dependency set.
-An additional API 34 consumer job uses Core 1.17.0 and Fragment 1.8.9, pinned
-stable versions compatible with the fixture's SDK 36 toolchain. This is a
+The Gradle plugin matrix checks the minimum AndroidX dependency set. Consumer
+device jobs cover both the published minimum (Core 1.0.2 / Fragment 1.0.0 on
+API 21) and upgraded dependencies (Core 1.17.0 / Fragment 1.8.9 on API 34), with
+all four daily/online Debug/Release variants in each job. The upgraded versions
+are pinned baselines compatible with the fixture's SDK 36 toolchain. This is a
 consumer dependency override, not an upgrade of ARouter's published minimums.
 See the [Core](https://developer.android.com/jetpack/androidx/releases/core#1.17.0)
 and [Fragment](https://developer.android.com/jetpack/androidx/releases/fragment#1.8.9)
@@ -66,9 +68,17 @@ AROUTER_RUN_DEVICE_TESTS=true AROUTER_KEEP_TEST_ROOT=true \
 This verifies configuration-cache reuse, incremental route updates, flavor
 isolation, and all four daily/online Debug/Release variants. Device tests launch
 the consumer through Android components and check actual routing after provider,
-Fragment argument/injection, and ActivityOptionsCompat checks. There are no
-test-only keep rules in this consumer, including its Release/R8 runs. Jetifier
+Fragment/DialogFragment argument/injection, and ActivityOptionsCompat checks.
+There are no test-only keep rules in this consumer, including its Release/R8 runs. Jetifier
 is disabled throughout.
+
+To run the minimum dependency job on an API 21 emulator, use the same command
+with `AROUTER_MIN_SDK=14`, `AROUTER_ANDROIDX_CORE_VERSION=1.0.2`, and
+`AROUTER_ANDROIDX_FRAGMENT_VERSION=1.0.0`. Do not substitute newer dependencies
+for this check: newer Fragment artifacts have constructor keep rules that can
+hide missing rules in ARouter. Fragment routes require public no-argument
+constructors, and ARouter's own consumer rules preserve them. Routing a
+DialogFragment only creates the instance; the caller owns displaying it.
 
 CI preserves device reports and R8 mappings even when tests fail. Set
 `AROUTER_KEEP_TEST_ROOT=true` to retain local fixture output; its exact path is

--- a/gradle/TESTING.md
+++ b/gradle/TESTING.md
@@ -34,6 +34,10 @@ or skipped tests. Local copies are retained by API and build type under
 
 ## Published-artifact consumer
 
+The dependency verifier requires `rg` (ripgrep), `unzip`, and `strings`
+(`binutils` on Linux). CI installs these tools explicitly; they must also be on
+`PATH` when running the verifier locally.
+
 First stage all four local artifacts using JDK 8:
 
 ```sh

--- a/gradle/configuration-cache-fixture/app/build.gradle
+++ b/gradle/configuration-cache-fixture/app/build.gradle
@@ -54,6 +54,7 @@ android {
 dependencies {
     implementation "com.alibaba:arouter-api:${rootProject.findProperty('arouter.api.version')}"
     annotationProcessor "com.alibaba:arouter-compiler:${rootProject.findProperty('arouter.compiler.version')}"
+    implementation 'androidx.fragment:fragment:1.0.0'
     dailyImplementation project(':feature-daily')
     onlineImplementation project(':feature-online')
 }

--- a/gradle/configuration-cache-fixture/app/build.gradle
+++ b/gradle/configuration-cache-fixture/app/build.gradle
@@ -10,13 +10,17 @@ android {
     namespace 'com.alibaba.android.arouter.configcache'
     compileSdkVersion fixtureCompileSdk
     buildToolsVersion fixtureBuildTools
+    if (rootProject.hasProperty('arouter.test.build.type')) {
+        testBuildType rootProject.property('arouter.test.build.type')
+    }
 
     defaultConfig {
         applicationId 'com.alibaba.android.arouter.configcache'
-        minSdkVersion 14
+        minSdkVersion Integer.parseInt((rootProject.findProperty('arouter.min.sdk') ?: '14').toString())
         targetSdkVersion fixtureCompileSdk
         versionCode 1
         versionName '1.0'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -54,7 +58,13 @@ android {
 dependencies {
     implementation "com.alibaba:arouter-api:${rootProject.findProperty('arouter.api.version')}"
     annotationProcessor "com.alibaba:arouter-compiler:${rootProject.findProperty('arouter.compiler.version')}"
-    implementation 'androidx.fragment:fragment:1.0.0'
+    // The default checks the published minimum; overrides model a consumer
+    // upgrading AndroidX without changing ARouter's published dependencies.
+    if (rootProject.hasProperty('arouter.androidx.core.version')) {
+        implementation "androidx.core:core:${rootProject.property('arouter.androidx.core.version')}"
+    }
+    implementation "androidx.fragment:fragment:${rootProject.findProperty('arouter.androidx.fragment.version') ?: '1.0.0'}"
+    androidTestImplementation 'androidx.test:runner:1.3.0'
     dailyImplementation project(':feature-daily')
     onlineImplementation project(':feature-online')
 }

--- a/gradle/configuration-cache-fixture/app/src/androidTest/java/com/alibaba/android/arouter/configcache/AndroidXConsumerInstrumentedTest.java
+++ b/gradle/configuration-cache-fixture/app/src/androidTest/java/com/alibaba/android/arouter/configcache/AndroidXConsumerInstrumentedTest.java
@@ -1,0 +1,54 @@
+package com.alibaba.android.arouter.configcache;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(JUnit4.class)
+public class AndroidXConsumerInstrumentedTest {
+    @Test
+    public void publishedArtifactsRouteWithConsumerAndroidXDependencies() {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        // Use component names instead of target-APK API calls. Release tests
+        // must exercise the real consumer R8 rules, without test-only keep rules.
+        Instrumentation.ActivityMonitor monitor = instrumentation.addMonitor(
+                "com.alibaba.android.arouter.configcache.SecondActivity", null, false);
+        Activity probe = null;
+        Activity destination = null;
+        try {
+            Intent intent = new Intent();
+            intent.setClassName(instrumentation.getTargetContext(),
+                    "com.alibaba.android.arouter.configcache.ProbeActivity");
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            probe = instrumentation.startActivitySync(intent);
+            // ProbeActivity only navigates after provider registration, Fragment
+            // arguments/injection and ActivityOptionsCompat have all succeeded.
+            destination = monitor.waitForActivityWithTimeout(10000);
+            assertNotNull("AndroidX consumer navigation did not arrive", destination);
+        } finally {
+            finish(instrumentation, destination);
+            finish(instrumentation, probe);
+            instrumentation.removeMonitor(monitor);
+        }
+    }
+
+    private static void finish(Instrumentation instrumentation, final Activity activity) {
+        if (activity != null) {
+            instrumentation.runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    activity.finish();
+                }
+            });
+            instrumentation.waitForIdleSync();
+        }
+    }
+}

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeDialogFragment.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeDialogFragment.java
@@ -1,0 +1,12 @@
+package com.alibaba.android.arouter.configcache;
+
+import androidx.fragment.app.DialogFragment;
+
+import com.alibaba.android.arouter.facade.annotation.Autowired;
+import com.alibaba.android.arouter.facade.annotation.Route;
+
+@Route(path = "/cache/androidx-dialog")
+public final class AndroidXProbeDialogFragment extends DialogFragment {
+    @Autowired
+    public String source;
+}

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeFragment.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeFragment.java
@@ -1,0 +1,9 @@
+package com.alibaba.android.arouter.configcache;
+
+import androidx.fragment.app.Fragment;
+
+import com.alibaba.android.arouter.facade.annotation.Route;
+
+@Route(path = "/cache/androidx-fragment")
+public final class AndroidXProbeFragment extends Fragment {
+}

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeFragment.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/AndroidXProbeFragment.java
@@ -3,7 +3,10 @@ package com.alibaba.android.arouter.configcache;
 import androidx.fragment.app.Fragment;
 
 import com.alibaba.android.arouter.facade.annotation.Route;
+import com.alibaba.android.arouter.facade.annotation.Autowired;
 
 @Route(path = "/cache/androidx-fragment")
 public final class AndroidXProbeFragment extends Fragment {
+    @Autowired
+    public String source;
 }

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
@@ -38,6 +38,10 @@ public class ProbeActivity extends Activity {
                 || !"configuration-cache-fixture".equals(arguments.getString("source"))) {
             throw new IllegalStateException("Cannot pass AndroidX Fragment route arguments");
         }
+        ARouter.getInstance().inject(fragment);
+        if (!"configuration-cache-fixture".equals(((AndroidXProbeFragment) fragment).source)) {
+            throw new IllegalStateException("Cannot inject AndroidX Fragment route arguments");
+        }
 
         Postcard activityPostcard = ARouter.getInstance().build("/cache/second");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
@@ -1,9 +1,13 @@
 package com.alibaba.android.arouter.configcache;
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.core.app.ActivityOptionsCompat;
+
+import com.alibaba.android.arouter.facade.Postcard;
 import com.alibaba.android.arouter.facade.template.IProvider;
 import com.alibaba.android.arouter.launcher.ARouter;
 
@@ -22,6 +26,32 @@ public class ProbeActivity extends Activity {
         }
         Log.i("ARouterFixture", "Resolved feature provider " + featureRoute);
 
-        ARouter.getInstance().build("/cache/second").navigation(this);
+        Object fragment = ARouter.getInstance()
+                .build("/cache/androidx-fragment")
+                .withString("source", "configuration-cache-fixture")
+                .navigation();
+        if (!(fragment instanceof AndroidXProbeFragment)) {
+            throw new IllegalStateException("Cannot resolve AndroidX Fragment route");
+        }
+        Bundle arguments = ((AndroidXProbeFragment) fragment).getArguments();
+        if (arguments == null
+                || !"configuration-cache-fixture".equals(arguments.getString("source"))) {
+            throw new IllegalStateException("Cannot pass AndroidX Fragment route arguments");
+        }
+
+        Postcard activityPostcard = ARouter.getInstance().build("/cache/second");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
+                    this,
+                    android.R.anim.fade_in,
+                    android.R.anim.fade_out
+            );
+            if (activityPostcard.withOptionsCompat(options) != activityPostcard
+                    || activityPostcard.getOptionsBundle() == null) {
+                throw new IllegalStateException("AndroidX ActivityOptionsCompat contract is unavailable");
+            }
+        }
+
+        activityPostcard.navigation(this);
     }
 }

--- a/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
+++ b/gradle/configuration-cache-fixture/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java
@@ -43,6 +43,20 @@ public class ProbeActivity extends Activity {
             throw new IllegalStateException("Cannot inject AndroidX Fragment route arguments");
         }
 
+        Object dialog = ARouter.getInstance().build("/cache/androidx-dialog")
+                .withString("source", "dialog-fixture").navigation();
+        if (!(dialog instanceof AndroidXProbeDialogFragment)) {
+            throw new IllegalStateException("Cannot resolve AndroidX DialogFragment route");
+        }
+        AndroidXProbeDialogFragment routedDialog = (AndroidXProbeDialogFragment) dialog;
+        ARouter.getInstance().inject(routedDialog);
+        if (routedDialog.getArguments() == null
+                || !"dialog-fixture".equals(routedDialog.getArguments().getString("source"))
+                || !"dialog-fixture".equals(routedDialog.source)
+                || routedDialog.isAdded() || routedDialog.getDialog() != null) {
+            throw new IllegalStateException("DialogFragment creation/injection contract changed");
+        }
+
         Postcard activityPostcard = ARouter.getInstance().build("/cache/second");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(

--- a/gradle/configuration-cache-fixture/gradle.properties
+++ b/gradle/configuration-cache-fixture/gradle.properties
@@ -1,3 +1,5 @@
 android.r8.failOnMissingClasses=true
 android.suppressUnsupportedCompileSdk=33
+android.useAndroidX=true
+android.enableJetifier=false
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/gradle/verify-androidx.sh
+++ b/gradle/verify-androidx.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
+for tool in rg unzip strings; do
+    command -v "${tool}" >/dev/null || { echo "Missing required tool: ${tool}" >&2; exit 1; }
+done
 dependency_log="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-dependencies.XXXXXX")"
 classes_jar="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-classes.XXXXXX")"
 class_strings="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-strings.XXXXXX")"
@@ -37,6 +40,12 @@ if rg --line-number \
     echo "Legacy Support Library references remain in AndroidX runtime sources:" >&2
     cat "${dependency_log}" >&2
     exit 1
+else
+    scan_status=$?
+    if [[ ${scan_status} -ne 1 ]]; then
+        echo "Failed to scan AndroidX runtime sources (exit ${scan_status})." >&2
+        exit "${scan_status}"
+    fi
 fi
 
 grep -Fxq 'android.useAndroidX=true' gradle.properties
@@ -44,8 +53,14 @@ grep -Fxq 'android.enableJetifier=false' gradle.properties
 grep -Fxq 'android.useAndroidX=true' gradle/configuration-cache-fixture/gradle.properties
 grep -Fxq 'android.enableJetifier=false' gradle/configuration-cache-fixture/gradle.properties
 
-./gradlew --no-daemon --console=plain -q -Parouter.useLocalRegisterPlugin \
+./gradlew "$@" --no-daemon --console=plain -q -Parouter.useLocalRegisterPlugin \
     :app:dependencies --configuration debugRuntimeClasspath >"${dependency_log}"
+
+if grep -Eq '(^|[[:space:]])FAILED([[:space:]]|$)' "${dependency_log}"; then
+    echo "The AndroidX dependency graph contains unresolved dependencies:" >&2
+    cat "${dependency_log}" >&2
+    exit 1
+fi
 
 if grep -Fq 'com.android.support' "${dependency_log}"; then
     echo "Legacy Support Library artifacts remain on the demo runtime classpath:" >&2

--- a/gradle/verify-androidx.sh
+++ b/gradle/verify-androidx.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+dependency_log="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-dependencies.XXXXXX")"
+classes_jar="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-classes.XXXXXX")"
+class_strings="$(mktemp "${TMPDIR:-/tmp}/arouter-androidx-strings.XXXXXX")"
+
+cleanup() {
+    rm -f -- "${dependency_log}" "${classes_jar}" "${class_strings}"
+}
+trap cleanup EXIT
+
+cd "${repo_root}"
+
+# The compiler intentionally retains string-only detection for legacy Fragment
+# sources so it can still be paired with the 1.x runtime. Runtime artifacts and
+# demos must be native AndroidX, which is the scope checked below.
+runtime_paths=(
+    README.md
+    README_CN.md
+    app
+    arouter-api
+    gradle/configuration-cache-fixture
+    gradle.properties
+    module-java
+    module-java-export
+    module-kotlin
+)
+
+if rg --line-number \
+    --glob '!**/build/**' \
+    --glob '!**/.gradle/**' \
+    'android\.support|com\.android\.support' \
+    "${runtime_paths[@]}" >"${dependency_log}"; then
+    echo "Legacy Support Library references remain in AndroidX runtime sources:" >&2
+    cat "${dependency_log}" >&2
+    exit 1
+fi
+
+grep -Fxq 'android.useAndroidX=true' gradle.properties
+grep -Fxq 'android.enableJetifier=false' gradle.properties
+grep -Fxq 'android.useAndroidX=true' gradle/configuration-cache-fixture/gradle.properties
+grep -Fxq 'android.enableJetifier=false' gradle/configuration-cache-fixture/gradle.properties
+
+./gradlew --no-daemon --console=plain -q -Parouter.useLocalRegisterPlugin \
+    :app:dependencies --configuration debugRuntimeClasspath >"${dependency_log}"
+
+if grep -Fq 'com.android.support' "${dependency_log}"; then
+    echo "Legacy Support Library artifacts remain on the demo runtime classpath:" >&2
+    grep -F 'com.android.support' "${dependency_log}" >&2
+    exit 1
+fi
+
+for dependency in \
+    'androidx.core:core:' \
+    'androidx.fragment:fragment:' \
+    'androidx.appcompat:appcompat:' \
+    'androidx.constraintlayout:constraintlayout:'; do
+    if ! grep -Fq "${dependency}" "${dependency_log}"; then
+        echo "Missing AndroidX runtime dependency: ${dependency}" >&2
+        exit 1
+    fi
+done
+
+api_version="$(awk -F= '$1 == "VERSION_NAME" { print $2; exit }' arouter-api/gradle.properties)"
+published_dir="${repo_root}/build/localMaven/com/alibaba/arouter-api/${api_version}"
+published_pom="${published_dir}/arouter-api-${api_version}.pom"
+published_aar="${published_dir}/arouter-api-${api_version}.aar"
+
+for artifact in "${published_pom}" "${published_aar}"; do
+    if [[ ! -s "${artifact}" ]]; then
+        echo "Missing local ARouter API artifact: ${artifact}" >&2
+        echo "Run :arouter-api:installLocally before this verifier." >&2
+        exit 1
+    fi
+done
+
+if [[ arouter-api/build.gradle -nt "${published_pom}" \
+        || gradle.properties -nt "${published_pom}" ]]; then
+    echo "Local ARouter API publication is older than the AndroidX build configuration." >&2
+    echo "Run :arouter-api:installLocally before this verifier." >&2
+    exit 1
+fi
+
+if grep -Fq '<groupId>com.android.support</groupId>' "${published_pom}"; then
+    echo "Published ARouter API POM still exposes the legacy Support Library." >&2
+    exit 1
+fi
+
+for group_id in androidx.core androidx.fragment; do
+    if ! grep -Fq "<groupId>${group_id}</groupId>" "${published_pom}"; then
+        echo "Published ARouter API POM is missing ${group_id}." >&2
+        exit 1
+    fi
+done
+
+if ! awk '
+    /<dependency>/ { block = "" }
+    { block = block $0 "\n" }
+    /<\/dependency>/ {
+        if (index(block, "<groupId>androidx.core</groupId>") &&
+                index(block, "<scope>compile</scope>")) {
+            found = 1
+        }
+        block = ""
+    }
+    END { exit found ? 0 : 1 }
+' "${published_pom}"; then
+    echo "Published ARouter API POM does not expose AndroidX Core at compile scope." >&2
+    exit 1
+fi
+
+unzip -p "${published_aar}" classes.jar >"${classes_jar}"
+unzip -p "${classes_jar}" | strings >"${class_strings}"
+
+if grep -Fq 'android/support/' "${class_strings}"; then
+    echo "Published ARouter API bytecode still references android.support classes." >&2
+    grep -F 'android/support/' "${class_strings}" >&2
+    exit 1
+fi
+
+for class_name in \
+    'androidx/core/app/ActivityOptionsCompat' \
+    'androidx/fragment/app/Fragment'; do
+    if ! grep -Fq "${class_name}" "${class_strings}"; then
+        echo "Published ARouter API bytecode is missing ${class_name}." >&2
+        exit 1
+    fi
+done
+
+echo "ARouter native AndroidX dependency verification passed with Jetifier disabled."

--- a/gradle/verify-configuration-cache.sh
+++ b/gradle/verify-configuration-cache.sh
@@ -13,6 +13,31 @@ use_configuration_cache="${AROUTER_CONFIGURATION_CACHE:-true}"
 keep_test_root="${AROUTER_KEEP_TEST_ROOT:-false}"
 compile_sdk="${AROUTER_COMPILE_SDK:-33}"
 build_tools_version="${AROUTER_BUILD_TOOLS:-33.0.2}"
+run_device_tests="${AROUTER_RUN_DEVICE_TESTS:-false}"
+
+case "${run_device_tests}" in
+    true|false) ;;
+    *) echo "AROUTER_RUN_DEVICE_TESTS must be true or false." >&2; exit 1 ;;
+esac
+if [[ "${run_device_tests}" == true ]]; then
+    adb="${ANDROID_SDK_ROOT:?Set ANDROID_SDK_ROOT for device tests}/platform-tools/adb"
+    device_list="$("${adb}" devices)"
+    serial="$(awk 'NR > 1 && $2 == "device" { print $1 }' <<< "${device_list}")"
+    if [[ "$(awk 'NR > 1 && NF { count++ } END { print count+0 }' <<< "${device_list}")" != 1 \
+            || "${serial}" != emulator-* ]]; then
+        echo "Connect exactly one booted emulator for the consumer device tests." >&2
+        exit 1
+    fi
+    if [[ -n "${ANDROID_SERIAL:-}" && "${ANDROID_SERIAL}" != "${serial}" ]]; then
+        echo "ANDROID_SERIAL does not match the consumer test emulator." >&2
+        exit 1
+    fi
+    export ANDROID_SERIAL="${serial}"
+    if [[ "$("${adb}" shell getprop sys.boot_completed | tr -d '\r')" != 1 ]]; then
+        echo "The consumer test emulator has not finished booting." >&2
+        exit 1
+    fi
+fi
 
 case "${plugin_pipeline}" in
     legacy|scoped) ;;
@@ -104,6 +129,16 @@ gradle_command+=(
     "-Parouter.agp.version=${agp_version}"
     "-Parouter.compile.sdk=${compile_sdk}"
     "-Parouter.build.tools=${build_tools_version}"
+    "-Parouter.min.sdk=${AROUTER_MIN_SDK:-14}"
+    "-Parouter.androidx.fragment.version=${AROUTER_ANDROIDX_FRAGMENT_VERSION:-1.0.0}"
+)
+if [[ -n "${AROUTER_ANDROIDX_CORE_VERSION:-}" ]]; then
+    gradle_command+=("-Parouter.androidx.core.version=${AROUTER_ANDROIDX_CORE_VERSION}")
+fi
+if [[ -n "${AROUTER_GRADLE_INIT_SCRIPT:-}" ]]; then
+    gradle_command+=(--init-script "${AROUTER_GRADLE_INIT_SCRIPT}")
+fi
+assemble_tasks=(
     :app:assembleDailyDebug
     :app:assembleDailyRelease
     :app:assembleOnlineDebug
@@ -233,11 +268,11 @@ first_log="${test_root}/first-build.log"
 second_log="${test_root}/second-build.log"
 incremental_log="${test_root}/incremental-build.log"
 
-"${gradle_command[@]}" | tee "${first_log}"
+"${gradle_command[@]}" "${assemble_tasks[@]}" | tee "${first_log}"
 if [[ "${use_configuration_cache}" == true ]]; then
     grep -F "Configuration cache entry stored." "${first_log}"
 
-    "${gradle_command[@]}" | tee "${second_log}"
+    "${gradle_command[@]}" "${assemble_tasks[@]}" | tee "${second_log}"
     grep -F "Reusing configuration cache." "${second_log}"
     grep -F "Configuration cache entry reused." "${second_log}"
 fi
@@ -247,7 +282,7 @@ perl -pi -e 's#/cache/second#/cache/updated#g' \
     "${project_dir}/app/src/main/java/com/alibaba/android/arouter/configcache/ProbeActivity.java" \
     "${project_dir}/app/src/main/java/com/alibaba/android/arouter/configcache/SecondActivity.java"
 
-"${gradle_command[@]}" | tee "${incremental_log}"
+"${gradle_command[@]}" "${assemble_tasks[@]}" | tee "${incremental_log}"
 if [[ "${use_configuration_cache}" == true ]]; then
     grep -F "Reusing configuration cache." "${incremental_log}"
     grep -F "Configuration cache entry reused." "${incremental_log}"
@@ -292,5 +327,33 @@ verify_apk_routes "${daily_debug_apk}" featuredaily featureonline
 verify_apk_routes "${daily_release_apk}" featuredaily featureonline
 verify_apk_routes "${online_debug_apk}" featureonline featuredaily
 verify_apk_routes "${online_release_apk}" featureonline featuredaily
+
+if [[ "${run_device_tests}" == true ]]; then
+    # Assembly/configuration-cache contracts were checked above. Device tasks
+    # are run separately, against both flavors and the genuinely shrunk APKs.
+    for test_type in debug release; do
+        if [[ "${test_type}" == debug ]]; then test_variant=Debug; else test_variant=Release; fi
+        report_marker="$(mktemp "${test_root}/device-${test_type}.XXXXXX")"
+        "${gradle_command[@]}" --no-configuration-cache \
+            "-Parouter.test.build.type=${test_type}" \
+            ":app:connectedDaily${test_variant}AndroidTest" \
+            ":app:connectedOnline${test_variant}AndroidTest" \
+            | tee "${test_root}/device-${test_type}.log"
+        report_count=0
+        while IFS= read -r -d '' report; do
+            if ! grep -Eq '<testsuite .*tests="[1-9][0-9]*"' "${report}" \
+                    || grep -Eq ' (failures|errors|skipped)="[1-9][0-9]*"' "${report}"; then
+                echo "Empty, failed, or skipped consumer device tests in ${report}." >&2
+                exit 1
+            fi
+            report_count=$((report_count + 1))
+        done < <(find "${project_dir}/app/build/outputs/androidTest-results/connected" \
+            -type f -name 'TEST-*.xml' -newer "${report_marker}" -print0)
+        if [[ ${report_count} -ne 2 ]]; then
+            echo "Expected fresh ${test_type} reports for both consumer flavors, found ${report_count}." >&2
+            exit 1
+        fi
+    done
+fi
 
 echo "ARouter Gradle plugin verification passed for AGP ${agp_version} (${plugin_pipeline})."

--- a/gradle/verify-device-tests.sh
+++ b/gradle/verify-device-tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+build_type="${1:-debug}"
+if [[ $# -gt 0 ]]; then shift; fi
+case "${build_type}" in
+    debug) variant=Debug ;;
+    release) variant=Release ;;
+    *) echo "Usage: $0 [debug|release] [Gradle options...]" >&2; exit 1 ;;
+esac
+
+sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+adb="${sdk_root}/platform-tools/adb"
+if [[ ! -x "${adb}" ]]; then adb="$(command -v adb)"; fi
+device_list="$("${adb}" devices)"
+devices=()
+while IFS= read -r serial; do
+    [[ -z "${serial}" ]] || devices+=("${serial}")
+done < <(awk 'NR > 1 && NF { print $1 }' <<< "${device_list}")
+
+# AGP's connected tasks must not accidentally include another device. This
+# verifier deliberately requires one booted emulator, including on local runs.
+if [[ ${#devices[@]} -ne 1 || "${devices[0]}" != emulator-* ]]; then
+    echo "Connect exactly one booted emulator before running device tests." >&2
+    exit 1
+fi
+serial="${devices[0]}"
+if [[ -n "${ANDROID_SERIAL:-}" && "${ANDROID_SERIAL}" != "${serial}" ]]; then
+    echo "ANDROID_SERIAL does not match the connected emulator." >&2
+    exit 1
+fi
+export ANDROID_SERIAL="${serial}"
+if [[ "$("${adb}" -s "${serial}" shell getprop sys.boot_completed | tr -d '\r')" != 1 ]]; then
+    echo "The emulator has not finished booting." >&2
+    exit 1
+fi
+api_level="$("${adb}" -s "${serial}" shell getprop ro.build.version.sdk | tr -d '\r')"
+if [[ -n "${AROUTER_EXPECT_API:-}" && "${api_level}" != "${AROUTER_EXPECT_API}" ]]; then
+    echo "Expected API ${AROUTER_EXPECT_API}, connected API ${api_level}." >&2
+    exit 1
+fi
+
+cd "${repo_root}"
+gradle_command=(./gradlew --no-daemon --console=plain --stacktrace "$@")
+"${gradle_command[@]}" :arouter-gradle-plugin:build
+tasks=(":app:connected${variant}AndroidTest")
+report_modules=(app)
+if [[ "${build_type}" == debug ]]; then
+    tasks=(:arouter-api:connectedDebugAndroidTest "${tasks[@]}")
+    report_modules+=(arouter-api)
+fi
+
+echo "Running all ${build_type} device tests on ${serial} (API ${api_level})."
+run_marker="$(mktemp "${TMPDIR:-/tmp}/arouter-device-run.XXXXXX")"
+trap 'rm -f -- "${run_marker}"' EXIT
+"${gradle_command[@]}" -Parouter.useLocalRegisterPlugin \
+    "-Parouter.testBuildType=${build_type}" "${tasks[@]}"
+
+for module in "${report_modules[@]}"; do
+    report_dir="${repo_root}/${module}/build/outputs/androidTest-results/connected"
+    archive_dir="${repo_root}/build/reports/device-tests/api-${api_level}/${build_type}/${module}"
+    mkdir -p "${archive_dir}"
+    report_count=0
+    while IFS= read -r -d '' report; do
+        if ! grep -Eq '<testsuite .*tests="[1-9][0-9]*"' "${report}" \
+                || grep -Eq ' (failures|errors|skipped)="[1-9][0-9]*"' "${report}"; then
+            echo "Empty, failed, or skipped device tests in ${report}." >&2
+            exit 1
+        fi
+        cp "${report}" "${archive_dir}/$(basename "${report}")"
+        report_count=$((report_count + 1))
+    done < <(find "${report_dir}" -type f -name 'TEST-*.xml' -newer "${run_marker}" -print0)
+    if [[ ${report_count} -eq 0 ]]; then
+        echo "Missing device-test reports for ${module}." >&2
+        exit 1
+    fi
+done
+if [[ "${build_type}" == release ]]; then
+    test -s app/build/outputs/mapping/release/mapping.txt
+fi
+echo "ARouter ${build_type} device tests passed on API ${api_level}."

--- a/module-java-export/build.gradle
+++ b/module-java-export/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation project(':arouter-annotation')
     implementation project(':arouter-api')
-    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "androidx.appcompat:appcompat:${ANDROIDX_APPCOMPAT_VERSION}"
     annotationProcessor project(':arouter-compiler')
 
 }

--- a/module-java/build.gradle
+++ b/module-java/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     implementation project(':module-java-export')
 
-    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "androidx.appcompat:appcompat:${ANDROIDX_APPCOMPAT_VERSION}"
     implementation("com.google.code.gson:gson:$gson_version") {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     }

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/AutowiredR8Fragment.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/AutowiredR8Fragment.java
@@ -1,6 +1,6 @@
 package com.alibaba.android.arouter.demo.module1;
 
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 
 import com.alibaba.android.arouter.facade.annotation.Autowired;
 

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/BlankFragment.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/BlankFragment.java
@@ -1,12 +1,12 @@
 package com.alibaba.android.arouter.demo.module1;
 
-
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
 
 import com.alibaba.android.arouter.demo.service.model.TestObj;
 import com.alibaba.android.arouter.demo.service.model.TestParcelable;

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/TestModule2Activity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/TestModule2Activity.java
@@ -1,7 +1,8 @@
 package com.alibaba.android.arouter.demo.module1;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.facade.annotation.Route;
 

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/BaseActivity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/BaseActivity.java
@@ -1,6 +1,6 @@
 package com.alibaba.android.arouter.demo.module1.testactivity;
 
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.facade.annotation.Autowired;
 

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test2Activity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test2Activity.java
@@ -1,9 +1,10 @@
 package com.alibaba.android.arouter.demo.module1.testactivity;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.demo.module1.R;
 import com.alibaba.android.arouter.facade.annotation.Autowired;

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test3Activity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test3Activity.java
@@ -1,8 +1,9 @@
 package com.alibaba.android.arouter.demo.module1.testactivity;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.demo.module1.R;
 import com.alibaba.android.arouter.facade.annotation.Autowired;

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test4Activity.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testactivity/Test4Activity.java
@@ -1,9 +1,10 @@
 package com.alibaba.android.arouter.demo.module1.testactivity;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.demo.module1.R;
 import com.alibaba.android.arouter.facade.annotation.Route;

--- a/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testinterceptor/LoginRedirectInterceptor.java
+++ b/module-java/src/main/java/com/alibaba/android/arouter/demo/module1/testinterceptor/LoginRedirectInterceptor.java
@@ -9,25 +9,42 @@ import com.alibaba.android.arouter.facade.template.IInterceptor;
 import com.alibaba.android.arouter.launcher.ARouter;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Interceptor(priority = 5, name = "login redirect contract probe")
 public class LoginRedirectInterceptor implements IInterceptor {
     private static final String PROTECTED_PATH = "/redirect/protected";
     private static final String LOGIN_PATH = "/redirect/login";
-    private static final AtomicInteger PROCESS_COUNT = new AtomicInteger();
+    private static final AtomicInteger PROTECTED_PROCESS_COUNT = new AtomicInteger();
+    private static final AtomicInteger WATCHED_POSTCARD_PROCESS_COUNT = new AtomicInteger();
+    private static final AtomicReference<Postcard> WATCHED_POSTCARD = new AtomicReference<Postcard>();
 
     public static void resetProbe() {
-        PROCESS_COUNT.set(0);
+        WATCHED_POSTCARD.set(null);
+        PROTECTED_PROCESS_COUNT.set(0);
+        WATCHED_POSTCARD_PROCESS_COUNT.set(0);
     }
 
-    public static int processCount() {
-        return PROCESS_COUNT.get();
+    public static int protectedProcessCount() {
+        return PROTECTED_PROCESS_COUNT.get();
+    }
+
+    public static void watchPostcard(Postcard postcard) {
+        WATCHED_POSTCARD.set(postcard);
+        WATCHED_POSTCARD_PROCESS_COUNT.set(0);
+    }
+
+    public static int watchedPostcardProcessCount() {
+        return WATCHED_POSTCARD_PROCESS_COUNT.get();
     }
 
     @Override
     public void process(Postcard postcard, InterceptorCallback callback) {
-        PROCESS_COUNT.incrementAndGet();
+        if (postcard == WATCHED_POSTCARD.get()) {
+            WATCHED_POSTCARD_PROCESS_COUNT.incrementAndGet();
+        }
         if (PROTECTED_PATH.equals(postcard.getPath())) {
+            PROTECTED_PROCESS_COUNT.incrementAndGet();
             callback.onInterrupt(new IllegalStateException("Login is required."));
             ARouter.getInstance()
                     .build(LOGIN_PATH)

--- a/module-kotlin/build.gradle
+++ b/module-kotlin/build.gradle
@@ -14,9 +14,9 @@ dependencies {
     implementation project(':arouter-api')
     implementation project(':arouter-annotation')
     kapt project(':arouter-compiler')
-    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "androidx.appcompat:appcompat:${ANDROIDX_APPCOMPAT_VERSION}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation "androidx.constraintlayout:constraintlayout:${ANDROIDX_CONSTRAINTLAYOUT_VERSION}"
 }
 android {
     compileSdkVersion Integer.parseInt(COMPILE_SDK_VERSION)

--- a/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/TestNormalActivity.java
+++ b/module-kotlin/src/main/java/com/alibaba/android/arouter/demo/kotlin/TestNormalActivity.java
@@ -1,7 +1,8 @@
 package com.alibaba.android.arouter.demo.kotlin;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.alibaba.android.arouter.facade.annotation.Route;
 

--- a/module-kotlin/src/main/res/layout/activity_test_normal.xml
+++ b/module-kotlin/src/main/res/layout/activity_test_normal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -7,4 +7,4 @@
     android:layout_height="match_parent"
     tools:context="com.alibaba.android.arouter.demo.kotlin.TestNormalActivity">
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary

- Migrate the runtime, demo and instrumentation suites to native AndroidX, with Jetifier disabled.
- Keep compiler-side string detection for legacy Fragment types so the compiler can still be paired with the 1.x runtime.
- Isolate the interceptor redirect test probe and synchronize Activity destruction between repeated navigation requests.
- Add API 21/34 Debug and Release/R8 CI jobs, plus independent consumers using both minimum and upgraded AndroidX dependencies.
- Preserve the target class and original Throwable when Fragment construction fails, without changing the existing null-return contract.
- Retain public no-argument Fragment constructors under R8 and cover normal Fragment and DialogFragment routing in the independent consumer.

Refs #785. Issue status and release tracking will be handled separately.

## Compatibility

- This is a source and binary compatibility boundary for Support Library applications, notably the ActivityOptionsCompat API. The README documents the migration requirement and major-version release boundary.
- ARouter's minSdkVersion remains 14. Runtime device coverage in this change starts at API 21, not API 14.
- The published minimum AndroidX dependencies remain Core 1.0.2 / Fragment 1.0.0. Core 1.17.0 / Fragment 1.8.9 are overrides in the independent consumer fixture only.
- No new routing semantics, repeatable Route annotations, KSP processor, Compose adapter or dynamic-feature behavior is introduced.
- This PR targets develop only. No version bump, publication, tag or master update is included.

## Validation

- 35 local unit tests passed, including missing-constructor, throwing-constructor and null-destination diagnostics.
- Complete device suites passed on API 21 and 34: 16 API-module plus 30 demo tests per Debug run, and 30 demo tests per minified Release run, for 152 test executions.
- Eight independent consumer variants passed: daily/online × Debug/Release for Core 1.0.2 / Fragment 1.0.0 on API 21 and Core 1.17.0 / Fragment 1.8.9 on API 34, with Jetifier disabled and without test-only consumer keep rules.
- A red/green consumer reproduction confirmed that the original candidate loses a valid DialogFragment constructor under R8 with the minimum dependencies; the constructor-retention fix passes the same case. Fragment construction failures still return null, and displaying DialogFragments remains the caller's responsibility.
- Gradle plugin validation covers configuration-cache reuse, incremental route updates and flavor isolation; reproduction commands are in gradle/TESTING.md.
- Actionlint, ShellCheck for the AndroidX/device verification scripts, and git diff --check passed.
- Remote CI results remain an acceptance requirement.

The verification scripts reject missing/old test reports, failed or skipped tests, unresolved dependencies, and unintended device targets. Test artifacts and R8 mappings are retained by CI for diagnosis.