### PR TITLE
ci: run artifact uploads on Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Preserve device reports and R8 mappings
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: device-tests-api-${{ matrix.api }}-${{ matrix.build_type }}
           retention-days: 14


### PR DESCRIPTION
## Summary

- Pin `actions/upload-artifact` to the official v7.0.1 commit, which declares Node 24, replacing the Node 20 action used by the device report upload step.
- Preserve the existing test matrix, permissions, artifact names, upload paths and 14-day retention.
- Keep default ZIP archiving, hidden-file exclusion and non-overwriting uploads. No Android runtime, API, dependency baseline or release configuration changes.

## Validation

- `actionlint .github/workflows/build.yml` passed.
- `git diff --check` passed.
- Compared the old and new action manifests: existing input defaults/requirements and outputs are compatible; ZIP archiving remains enabled by default.
- Compared the full workflow structure and checked all six artifact names for uniqueness; only the pinned action reference changes.
- Remote validation is pending: run the existing CI matrix and verify the six uploaded device artifacts, JUnit reports and Release/R8 mappings before merge. The earlier develop run used the old action and is not evidence for this upload change.

Target: `develop`. Publication remains out of scope.